### PR TITLE
mint.narrow,mint.nonzero,mint.split,mint.tile,mint.tril接口测试

### DIFF
--- a/test/test_narrow.py
+++ b/test/test_narrow.py
@@ -1,0 +1,222 @@
+import pytest
+import numpy as np
+import mindspore
+import torch
+
+"""
+    测试mindspore.mint.narrow接口
+    mindspore.mint.narrow(input, dim, start, length)
+        沿着指定的轴，指定起始位置获取指定长度的Tensor。
+"""
+@pytest.mark.parametrize("dtype", [ 
+    np.bool_,
+    np.int_,
+    np.intc,
+    np.intp,
+    np.int8,
+    np.int16,
+    np.int32, 
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32, 
+    np.uint64,
+    np.float_,
+    np.float16,
+    np.float32, 
+    np.float64,
+    np.complex_,
+    np.complex64,
+    np.complex128
+])
+def test_narrow_random_input_dtype(dtype):
+    """
+    测试random输入不同dtype，对比MindSpore和Pytorch的支持度
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag1 = True
+    flag2 = True
+    shape = (4, 4)
+    dim = 0
+    start = 1
+    length = 2
+    try:
+        # MindSpore
+        input_ms = mindspore.Tensor(np.random.random(size=shape).astype(dtype))
+        result_ms = mindspore.mint.narrow(input_ms, dim, start, length)
+        print(result_ms)
+        assert isinstance(result_ms, mindspore.Tensor)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag1 = False
+
+    try:
+        # Pytorch
+        input_pt = torch.from_numpy(np.random.random(size=shape).astype(dtype))
+        result_pt = torch.narrow(input_pt, dim, start, length)
+        assert isinstance(result_pt, torch.Tensor)
+
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag2 = False
+    if not flag1 and flag2:
+        pytest.fail("mindspore不支持："+str(dtype))
+    if flag1 and not flag2:
+        pytest.fail("pytorch不支持："+str(dtype))
+    if not flag1 and not flag2:
+        pytest.fail("both mindspore 和 pytorch不支持："+str(dtype))
+
+
+
+@pytest.mark.parametrize("input_shape", [
+    (2,2),
+    (4,4),
+    (32,32),
+    (64,64,64)
+])
+def test_narrow_fixed_dtype_random_value(input_shape):
+    """
+    测试固定dtype，random输入值，对比两个框架输出（误差范围小于1e-3）
+    """
+    try:
+        input = np.random.random(size=input_shape).astype(np.float32)
+        dim = 0
+        start = 1
+        length = 1
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input)
+        result_ms1 = mindspore.mint.narrow(input_ms, dim, start, length)
+        a = result_ms1.asnumpy()
+        # Pytorch部分
+        input_pt = torch.from_numpy(input)
+        result_pt = torch.narrow(input_pt, dim, start, length)
+
+        assert np.allclose(a, result_pt.numpy(), atol=1e-3)
+    except Exception as e:
+        print(f"出现报错: {e}")
+        pytest.fail(e)
+
+
+@pytest.mark.parametrize("input_param", [(0, 1, 1)])
+def test_narrow_fixed_shape_fixed_value_different_params(input_param):
+    """
+    测试固定shape，固定输入值，不同输入参数类型，两个框架的支持度
+    """
+    input_value = np.array([[1, 2], [3, 4]]).astype(np.float32)
+    dim, start, length = input_param
+    flag = True
+    try:
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_value)
+        result_ms = mindspore.mint.narrow(input_ms, dim, start, length)
+
+        assert isinstance(result_ms, mindspore.Tensor)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag = False
+    try:
+        # Pytorch部分
+        input_pt = torch.from_numpy(input_value)
+        result_pt = torch.narrow(input_pt, dim, start, length)
+
+        assert isinstance(result_pt, torch.Tensor)
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag = False
+    assert flag
+
+
+@pytest.mark.parametrize("random_messy_input", [
+    ([[1, 2], [3, 4]], 0, 0, 1, TypeError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 2, 0, 1, ValueError),
+    (mindspore.tensor([[1, 2], [3, 4]]), -3, 0, 1, ValueError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 0, 2, 1, ValueError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 0, -3, 1, ValueError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 0, 0, 3, ValueError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 0, 0, -1, ValueError)
+])
+def test_narrow_random_messy_input_error_info(random_messy_input):
+    """
+    测试随机混乱输入，报错信息的准确性
+    """
+    flag = False
+    input = random_messy_input[0]
+    dim = random_messy_input[1]
+    start = random_messy_input[2]
+    length = random_messy_input[3]
+    try:
+        result_ms = mindspore.mint.narrow(input, dim, start, length)
+        print(result_ms)
+    except Exception as e_ms:
+        flag = True
+        assert isinstance(e_ms, random_messy_input[4])
+        
+    if not flag:
+        pytest.fail("在预期应捕获异常的情况下，未捕获到任何异常，测试不通过")
+
+
+
+
+# 测试使用该接口的构造函数的准确性
+
+
+def test_narrow_in_neural_network():
+    """
+    测试一个包含narrow操作的网络示例
+    """
+    input_value = np.random.random(size=(4,4)).astype(np.float32)
+
+    # mindspore
+    class SimpleNet_ms(mindspore.nn.Cell):
+        def __init__(self):
+            super(SimpleNet_ms, self).__init__()
+
+        def construct(self, x):
+            narrow_result = mindspore.mint.narrow(x, 0, 1, 2)
+            return narrow_result
+
+    input_ms = mindspore.Tensor(input_value)
+    net_ms = SimpleNet_ms()
+    result_ms = net_ms(input_ms)
+
+    # pytorch
+    class SimpleNet_pt(torch.nn.Module):
+        def __init__(self):
+            super(SimpleNet_pt, self).__init__()
+
+        def forward(self, x):
+            narrow_result = torch.narrow(x, 0, 1, 2)
+            return narrow_result
+
+    input_pt = torch.from_numpy(input_value)
+    net_pt = SimpleNet_pt()
+    result_pt = net_pt(input_pt)
+
+    assert np.allclose(result_ms.asnumpy(), result_pt.numpy(), atol=1e-3)
+
+
+def test_narrow_backward():
+    """
+    测试函数反向 
+    """
+    # 定义简单函数
+    def function_ms(x):
+        return mindspore.mint.narrow(x, 0, 1, 2).sum()
+    def function_pt(x):
+        return torch.narrow(x, 0, 1, 2).sum()
+
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    input_ms = mindspore.Tensor(input_value, mindspore.float32)
+    grad_ms = mindspore.grad(function_ms)(input_ms)
+
+    input_pt = torch.from_numpy(input_value).float().requires_grad_(True)
+    result_pt = function_pt(input_pt)
+    result_pt.backward()
+    grad_pt = input_pt.grad
+
+    assert np.allclose(grad_ms.asnumpy(), grad_pt.numpy(), atol=1e-3)
+
+
+
+

--- a/test/test_nonzero.py
+++ b/test/test_nonzero.py
@@ -1,0 +1,243 @@
+import mindspore.nn
+import pytest
+import numpy as np
+import mindspore
+import torch
+
+
+"""
+    测试mindspore.mint.nonzero接口
+    mindspore.mint.nonzero(input, as_tuple=False)
+        返回所有非零元素下标位置。
+"""
+
+@pytest.mark.parametrize("dtype", [ 
+    np.bool_,
+    np.int_,
+    np.intc,
+    np.intp,
+    np.int8,
+    np.int16,
+    np.int32, 
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32, 
+    np.uint64,
+    np.float_,
+    np.float16,
+    np.float32, 
+    np.float64,
+    np.complex_,
+    np.complex64,
+    np.complex128
+])
+def test_nonzero_random_input_dtype(dtype):
+    """
+    测试random输入不同dtype，对比MindSpore和Pytorch的支持度
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag1 = True
+    flag2 = True
+    
+    shape = (4, 4)
+    try:
+        # MindSpore
+        input_ms = mindspore.Tensor(np.random.random(size=shape).astype(dtype))
+        result_ms = mindspore.mint.nonzero(input_ms)
+
+        assert isinstance(result_ms, mindspore.Tensor) and result_ms.ndim >= 2
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag1 = False
+
+    try:
+        # Pytorch
+        input_pt = torch.from_numpy(np.random.random(size=shape).astype(dtype))
+        result_pt = torch.nonzero(input_pt)
+        assert isinstance(result_pt, torch.Tensor) and result_pt.ndim >= 2
+
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag2 = False
+
+    if not flag1 and flag2:
+        pytest.fail("mindspore不支持："+str(dtype))
+    if flag1 and not flag2:
+        pytest.fail("pytorch不支持："+str(dtype))
+    if not flag1 and not flag2:
+        pytest.fail("both mindspore 和 pytorch不支持："+str(dtype))
+
+
+@pytest.mark.parametrize("input_value", [np.array([[1, 0], [0, 1]]).astype(np.float32),
+                                        np.array([[0, 1], [1, 0]]).astype(np.float32),
+                                        np.array([[1, 1], [0, 0]]).astype(np.float32),
+                                        np.array([[0, 0], [1, 1]]).astype(np.float32)])
+def test_nonzero_fixed_dtype_random_value(input_value):
+    """
+    测试固定dtype，random输入值，对比两个框架输出（误差范围小于1e-3）
+    """
+    dtype = input_value.dtype
+    # MindSpore部分
+    input_ms = mindspore.Tensor(input_value)
+    result_ms = mindspore.mint.nonzero(input_ms)
+    print(result_ms.dtype)
+    # Pytorch部分
+    input_pt = torch.from_numpy(input_value)
+    result_pt = torch.nonzero(input_pt)
+
+    assert np.allclose(result_ms.asnumpy(), result_pt.numpy(), atol=1e-3)
+
+
+@pytest.mark.parametrize("input_param", [
+    False, 
+    True
+])
+def test_nonzero_fixed_shape_fixed_value_different_params(input_param):
+    """
+    测试固定shape，固定输入值，不同输入参数，两个框架的支持度
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    input_value = np.array([1,0,0,1]).astype(np.float32)
+    as_tuple = input_param
+    flag = True
+    try:
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_value)
+        result_ms = mindspore.mint.nonzero(input_ms, as_tuple=input_param)
+
+        if not as_tuple:
+            assert isinstance(result_ms, mindspore.Tensor)
+        else:
+            assert isinstance(result_ms, tuple)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag = False
+    try:
+        # Pytorch部分
+        input_pt = torch.from_numpy(input_value)
+        result_pt = torch.nonzero(input_pt,as_tuple=input_param)
+        
+        if not as_tuple:
+            assert isinstance(result_pt, torch.Tensor)
+        else:
+            assert isinstance(result_pt, tuple)
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag = False
+    assert flag
+
+
+@pytest.mark.parametrize("random_messy_input", [
+    (np.array([[1, 2], [3, 4]]).astype(np.float32), False, TypeError),
+    (mindspore.tensor([[1, 2], [3, 4]]), "str", TypeError),
+    (mindspore.tensor(0), False, ValueError)
+])
+def test_nonzero_random_messy_input_error_info(random_messy_input):
+    """
+    测试随机混乱输入，报错信息的准确性
+    TypeError - 如果 input 不是Tensor。
+    TypeError - 如果 as_tuple 不是bool。
+    ValueError - 如果 input 的维度为0。
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag = False
+    input = random_messy_input[0]
+    as_tuple = random_messy_input[1]
+    try:
+        result_ms = mindspore.mint.nonzero(input, as_tuple=as_tuple)
+        print(result_ms)
+    except Exception as e_ms:
+        assert isinstance(e_ms, random_messy_input[2])
+        flag = True
+    if not flag:
+        pytest.fail("在预期应捕获异常的情况下，未捕获到任何异常，测试不通过")
+
+
+
+# 以下测试使用该接口的函数/神经网络的准确性
+
+
+def test_nonzero_in_neural_network():
+    """
+    测试包含nonzero操作的网络示例
+    """
+    input_value = np.random.random(size=(2, 10)).astype(np.float32)
+
+    class Net_ms(mindspore.nn.Cell):
+        def __init__(self):
+            super(Net_ms, self).__init__()
+        def construct(self, x):
+            nonzero_indices = mindspore.mint.nonzero(x)
+            mask = mindspore.ops.ZerosLike()(x)
+            for index in nonzero_indices:
+                mask[index[0], index[1]] = 1
+            out = x * mask
+            return out.sum()
+        
+    class Net_pt(torch.nn.Module):
+        def __init__(self):
+            super(Net_pt, self).__init__()
+        def forward(self, x):
+            nonzero_indices = torch.nonzero(x)
+            mask = torch.zeros_like(x)
+            mask[nonzero_indices[:, 0], nonzero_indices[:, 1]] = 1
+            out = x * mask
+            return out.sum()
+
+    input_ms = mindspore.Tensor(input_value)
+    net_ms = Net_ms()
+    result_ms = net_ms(input_ms)
+
+
+    input_pt = torch.from_numpy(input_value)
+    net_pt = Net_pt()
+    result_pt = net_pt(input_pt)
+
+    assert np.allclose(result_ms.asnumpy(), result_pt.detach().numpy(), atol=1e-3)
+
+
+def test_nonzero_backward():
+    """
+    测试函数反向 
+    """
+    # 定义简单函数
+    class Net_ms(mindspore.nn.Cell):
+        def __init__(self):
+            super(Net_ms, self).__init__()
+            self.fc = mindspore.nn.Linear(10, 1)
+
+        def construct(self, x):
+            nonzero_indices = mindspore.mint.nonzero(x)
+            mask = mindspore.ops.ZerosLike()(x)
+            for index in nonzero_indices:
+                mask[index[0], index[1]] = 1
+            out = x * mask
+            return out.sum()
+        
+    class Net_pt(torch.nn.Module):
+        def __init__(self):
+            super(Net_pt, self).__init__()
+        def forward(self, x):
+            nonzero_indices = torch.nonzero(x)
+            mask = torch.zeros_like(x)
+            mask[nonzero_indices[:, 0], nonzero_indices[:, 1]] = 1
+            out = x * mask
+            return out.sum()
+
+
+    input_value = np.random.random(size=(2, 10)).astype(np.float32)
+
+    input_ms = mindspore.Tensor(input_value, mindspore.float32)
+    grad_ms = mindspore.grad(Net_ms())(input_ms)
+
+    input_pt = torch.from_numpy(input_value)
+    input_pt.requires_grad = True
+    result_pt = Net_pt()(input_pt)
+    result_pt.backward()
+    grad_pt = input_pt.grad
+
+    assert np.allclose(grad_ms.asnumpy(), grad_pt.numpy(), atol=1e-3)
+
+
+

--- a/test/test_split.py
+++ b/test/test_split.py
@@ -1,0 +1,224 @@
+import pytest
+import numpy as np
+import mindspore
+import mindspore.nn as nn
+import mindspore.ops as ops
+import torch
+
+
+"""
+    测试mindspore.mint.split接口
+    mindspore.mint.split: 将张量切块
+"""
+@pytest.mark.parametrize("dtype", [ 
+    np.bool_,
+    np.int_,
+    np.intc,
+    np.intp,
+    np.int8,
+    np.int16,
+    np.int32, 
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32, 
+    np.uint64,
+    np.float_,
+    np.float16,
+    np.float32, 
+    np.float64,
+    np.complex_,
+    np.complex64,
+    np.complex128
+])
+def test_split_random_input_dtype(dtype):
+    """
+    测试random输入不同dtype，对比MindSpore和Pytorch的支持度
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag1 = True
+    flag2 = True
+    shape = (4,4)
+    split_size_or_sections = [2, 2]
+    dim = 0
+    try:
+        # MindSpore
+        input_ms = mindspore.Tensor(np.random.random(size=shape).astype(dtype))
+        result_ms = mindspore.mint.split(input_ms, split_size_or_sections, dim)
+
+        assert isinstance(result_ms, tuple) and all(isinstance(x, mindspore.Tensor) for x in result_ms)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag1 = False
+
+    try:
+        # Pytorch
+        input_pt = torch.from_numpy(np.random.random(size=shape).astype(dtype))
+        result_pt = torch.split(input_pt, split_size_or_sections, dim)
+        assert isinstance(result_pt, tuple) and all(isinstance(x, torch.Tensor) for x in result_pt)
+
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag2 = False
+    if not flag1 and flag2:
+        pytest.fail("mindspore不支持："+str(dtype))
+    if flag1 and not flag2:
+        pytest.fail("pytorch不支持："+str(dtype))
+    if not flag1 and not flag2:
+        pytest.fail("both mindspore 和 pytorch不支持："+str(dtype))
+        
+
+
+@pytest.mark.parametrize("input_value", [np.array([[1, 2], [3, 4]]).astype(np.float32),
+                                        np.array([[5, 6], [7, 8]]).astype(np.float32),
+                                        np.array([[9, 10], [11, 12]]).astype(np.float32),
+                                        np.array([[13, 14], [15, 16]]).astype(np.float32)])
+def test_split_fixed_dtype_random_value(input_value):
+    """
+    测试固定dtype，random输入值，对比两个框架输出（误差范围小于1e-3）
+    """
+    dtype = input_value.dtype
+    split_size_or_sections = [1, 1]
+    dim = 0
+    # MindSpore部分
+    input_ms = mindspore.Tensor(input_value)
+    result_ms = mindspore.mint.split(input_ms, split_size_or_sections, dim)
+
+    # Pytorch部分
+    input_pt = torch.from_numpy(input_value)
+    result_pt = torch.split(input_pt, split_size_or_sections, dim)
+
+    for r_ms, r_pt in zip(result_ms, result_pt):
+        assert np.allclose(r_ms.asnumpy(), r_pt.numpy(), atol=1e-3)
+
+
+@pytest.mark.parametrize("input_param", [([1,1], 0), (2, 0)])
+def test_split_fixed_shape_fixed_value_different_params(input_param):
+    """
+    测试固定shape，固定输入值，不同输入参数类型，两个框架的支持度
+    split_size_or_sections参数的不同类型
+    """
+    split_size_or_sections, dim = input_param
+    input_value = np.array([[1, 2], [3, 4]]).astype(np.float32)
+    flag = True
+    try:
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_value)
+
+        result_ms = mindspore.mint.split(input_ms, split_size_or_sections, dim)
+
+        assert isinstance(result_ms, tuple)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag = False
+    try:
+        # Pytorch部分
+        input_pt = torch.from_numpy(input_value)
+  
+        result_pt = torch.split(input_pt, split_size_or_sections, dim)
+
+
+        assert isinstance(result_pt, tuple)
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag = False
+    assert flag
+
+
+@pytest.mark.parametrize("random_messy_input", [
+    ([[1, 2], [3, 4]], 2, 1,TypeError), 
+    (mindspore.tensor([[1, 2], [3, 4]]), 2, 1.0, TypeError),
+    (mindspore.tensor([[1, 2], [3, 4]]), 2, 3, ValueError),
+    (mindspore.tensor([[1, 2], [3, 4]]), [1.0, 1.0], 0, TypeError),
+    (mindspore.tensor([[1, 2], [3, 4]]), mindspore.tensor([1,1]), 1,TypeError),
+    (mindspore.tensor([[1, 2], [3, 4]]), [1,1,1], 0, ValueError)
+])
+def test_split_random_messy_input_error_info(random_messy_input):
+    """
+    测试随机混乱输入，报错信息的准确性
+        TypeError - tensor 不是Tensor。
+        TypeError - dim 不是int类型。
+        ValueError - dim 不在[-tensor.ndim, tensor.ndim)范围中。
+        TypeError - split_size_or_sections 中的每个元素不是int类型。
+        TypeError - split_size_or_sections 不是int，tuple(int)或list(int)。
+        ValueError - split_size_or_sections 的和不等于tensor.shape[dim]。
+    """
+    flag = False
+    input = random_messy_input[0]
+    split_size_or_sections = random_messy_input[1]
+    dim = random_messy_input[2]
+    try:
+        result_ms = mindspore.mint.split(input, split_size_or_sections, dim)
+    except Exception as e_ms:
+        assert isinstance(e_ms, random_messy_input[3])
+        flag = True
+    if not flag:
+        pytest.fail("在预期应捕获异常的情况下，未捕获到任何异常，测试不通过")
+
+
+
+
+# 以下测试使用该接口的构造函数/神经网络的准确性
+
+
+
+
+def test_split_in_neural_network():
+    """
+    测试一个包含split操作的网络示例
+    """
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    # mindspore
+    class SimpleNet_ms(nn.Cell):
+        def __init__(self):
+            super(SimpleNet_ms, self).__init__()
+
+        def construct(self, x):
+            split_result = mindspore.mint.split(x, 2, 0)
+            return split_result[0]
+
+    
+    input_ms = mindspore.Tensor(input_value)
+    net_ms = SimpleNet_ms()
+    result_ms = net_ms(input_ms)
+    
+    # pytorch
+    class SimpleNet_pt(torch.nn.Module):
+        def __init__(self):
+            super(SimpleNet_pt, self).__init__()
+
+        def forward(self, x):
+            split_result = torch.split(x, 2, 0)
+            return split_result[0]
+
+    input_pt = torch.from_numpy(input_value)
+    net_pt = SimpleNet_pt()
+    result_pt = net_pt(input_pt)
+
+    assert np.allclose(result_ms.asnumpy(), result_pt.numpy(), atol=1e-3)
+
+
+def test_split_backward():
+    """
+    测试函数反向 
+    """
+    # 定义简单函数
+    def function_ms(x):
+        return mindspore.mint.split(x,2,0)[0].sum()
+    def function_pt(x):
+        return torch.split(x,2,0)[0].sum()
+
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    input_ms = mindspore.Tensor(input_value, mindspore.float32)
+    grad_ms = mindspore.grad(function_ms)(input_ms)
+
+    input_pt = torch.from_numpy(input_value).float().requires_grad_(True)
+    result_pt = function_pt(input_pt)
+    result_pt.backward()
+    grad_pt = input_pt.grad
+
+    assert np.allclose(grad_ms.asnumpy(), grad_pt.numpy(), atol=1e-3)
+
+

--- a/test/test_tile.py
+++ b/test/test_tile.py
@@ -1,0 +1,216 @@
+import pytest
+import numpy as np
+import mindspore
+import torch
+
+
+"""
+mindspore.mint.tile(input, dims)
+    复制 dims 次 input 来创建新的Tensor。输出Tensor的第i维度有 input.shape[i] * dims[i] 个元素，并且 input 的值沿第i维度被复制 dims[i] 次。
+
+"""
+#用于比较MindSpore和PyTorch结果
+def compare_results_ms_pt(result_ms, result_pt, atol=1e-3):
+    try:
+        assert np.allclose(result_ms.asnumpy(), result_pt.detach().numpy(), atol=atol)
+    except AssertionError:
+        pytest.fail("MindSpore和PyTorch结果超出误差范围，不相等")
+
+
+
+@pytest.mark.parametrize("dtype", [ 
+    np.bool_,
+    np.int_,
+    np.intc,
+    np.intp,
+    np.int8,
+    np.int16,
+    np.int32, 
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32, 
+    np.uint64,
+    np.float_,
+    np.float16,
+    np.float32, 
+    np.float64,
+    np.complex_,
+    np.complex64,
+    np.complex128
+])
+def test_tile_random_dtype(dtype):
+    """
+    测试在随机输入不同数据类型时，MindSpore和PyTorch的tile接口的支持度。
+    参数：
+    - dtype：输入张量的数据类型，遍历多种常见类型进行测试。
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag1 = True
+    flag2 = True
+    input_shape = (2, 3) 
+    input_data = np.random.rand(*input_shape).astype(dtype)
+    multiples = (2, 2)
+    try:
+
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_data)  
+        result_ms = mindspore.mint.tile(input_ms, multiples)
+        assert isinstance(result_ms, mindspore.Tensor)
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag1 = False
+    try:
+        # PyTorch部分
+        input_pt = torch.from_numpy(input_data)
+        result_pt = torch.tile(input_pt, multiples)
+
+        assert isinstance(result_pt, torch.Tensor)
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag2 = False
+
+    if not flag1 and flag2:
+        pytest.fail("mindspore不支持："+str(dtype))
+    if flag1 and not flag2:
+        pytest.fail("pytorch不支持："+str(dtype))
+    if not flag1 and not flag2:
+        pytest.fail("both mindspore 和 pytorch不支持："+str(dtype))
+
+
+
+@pytest.mark.parametrize("input_shape", [
+    (3, 4), (2, 2, 2)
+])
+def test_tile_fixed_dtype_random_value(input_shape):
+    """
+    测试在固定数据类型，随机输入值的情况下，MindSpore和PyTorch的tile接口输出是否相等（在误差范围内）。
+    不同形状进行测试。
+    """
+    dtype = np.float32
+    input_data = np.random.rand(*input_shape).astype(dtype)
+    multiples = (2, 3)  
+    
+    # MindSpore部分
+    input_ms = mindspore.Tensor(input_data)
+    result_ms = mindspore.mint.tile(input_ms, multiples)
+
+    # PyTorch部分
+    input_pt = torch.from_numpy(input_data)
+    result_pt = torch.tile(input_pt, multiples)
+
+    compare_results_ms_pt(result_ms, result_pt)
+
+
+
+# @pytest.mark.parametrize("input_value", [
+#     "test_string", True, False
+# ])
+# def test_tile_fixed_shape_fixed_value(input_value):
+
+#     input_shape = ()  # 零维情况示例，对应输入单个值
+#     try:
+#         # MindSpore部分
+#         input_ms = mindspore.Tensor(input_value) if isinstance(input_value, (int, float, bool, str)) else input_value
+#         multiples = (2,)  # 设定重复倍数示例
+#         result_ms = mindspore.mint.tile(input_ms, multiples)
+
+#         # PyTorch部分
+#         input_pt = torch.tensor(input_value) if isinstance(input_value, (int, float, bool, str)) else input_value
+#         result_pt = torch.tile(input_pt, multiples)
+
+#         assert isinstance(result_ms, mindspore.Tensor) and isinstance(result_pt, torch.Tensor)
+#     except Exception as e:
+#         pytest.fail(f"输入值 {input_value} 时执行tile操作出现异常，异常信息: {str(e)}")
+
+
+
+@pytest.mark.parametrize("random_messy_input", [
+    (np.array([[1, 2], [3, 4]]).astype(np.float32), 2, TypeError),  
+    (np.array([1, 2]), (4.0,), TypeError),  
+    (np.array([1, 2]), (-1,), ValueError) 
+])
+def test_tile_random_messy_input_error_info(random_messy_input):
+    """
+    测试在随机混乱输入情况下，tile接口报错信息的准确性。
+    TypeError - dims 不是tuple或者其元素并非全部是int。
+    ValueError - dims 的元素并非全部大于或等于0
+    """
+    flag = False
+    input_data = random_messy_input[0]
+    multiples = random_messy_input[1]
+    try:
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_data)
+        result_ms = mindspore.mint.tile(input_ms, multiples)
+        print(result_ms)
+    except Exception as e_ms:
+        assert isinstance(e_ms,random_messy_input[2])
+        flag = True
+    if not flag:
+        pytest.fail("在预期应捕获异常的情况下，未捕获到任何异常，测试不通过")
+        
+
+                          
+                          
+# 以下测试使用该接口的构造函数/神经网络的准确性
+
+
+def test_tile_in_neural_network():
+    """
+    测试一个包含tile操作的网络示例
+    """
+    input_value = np.random.random(size=(4, 4)).astype(np.float32)
+
+    # mindspore
+    class SimpleNet_ms(mindspore.nn.Cell):
+        def __init__(self):
+            super(SimpleNet_ms, self).__init__()
+
+        def construct(self, x):
+            split_result = mindspore.mint.tile(x, (2,2))
+            return split_result.sum()
+
+    
+    input_ms = mindspore.Tensor(input_value)
+    net_ms = SimpleNet_ms()
+    result_ms = net_ms(input_ms)
+    
+    # pytorch
+    class SimpleNet_pt(torch.nn.Module):
+        def __init__(self):
+            super(SimpleNet_pt, self).__init__()
+
+        def forward(self, x):
+            split_result = torch.tile(x, (2,2))
+            return split_result.sum()
+
+    input_pt = torch.from_numpy(input_value)
+    net_pt = SimpleNet_pt()
+    result_pt = net_pt(input_pt)
+
+    compare_results_ms_pt(result_ms, result_pt)
+
+
+def test_tile_backward():
+    """
+    测试函数反向 
+    """
+    # 定义简单函数
+    def function_ms(x):
+        return mindspore.mint.tile(x,(2,1)).sum()
+    def function_pt(x):
+        return torch.tile(x,(2,1)).sum()
+
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    input_ms = mindspore.Tensor(input_value, mindspore.float32)
+    grad_ms = mindspore.grad(function_ms)(input_ms)
+
+    input_pt = torch.from_numpy(input_value).float().requires_grad_(True)
+    result_pt = function_pt(input_pt)
+    result_pt.backward()
+    grad_pt = input_pt.grad
+
+    compare_results_ms_pt(grad_ms, grad_pt)
+

--- a/test/test_tril.py
+++ b/test/test_tril.py
@@ -1,0 +1,200 @@
+import pytest
+import numpy as np
+import mindspore
+import torch
+
+
+""""
+mindspore.mint.tril(input, diagonal=0)
+    返回输入Tensor input 的下三角形部分(包含对角线和下面的元素)，并将其他元素设置为0。
+"""
+
+# 辅助函数
+def compare_results_ms_pt(result_ms, result_pt, atol=1e-3):
+    """
+    比较MindSpore和PyTorch的计算结果
+    """
+    try:
+        assert np.allclose(result_ms.asnumpy(), result_pt.detach().numpy(), atol=atol)
+    except AssertionError:
+        pytest.fail("MindSpore和PyTorch结果超出误差范围，不相等")
+
+
+
+@pytest.mark.parametrize("dtype", [ 
+    np.bool_,
+    np.int_,
+    np.intc,
+    np.intp,
+    np.int8,
+    np.int16,
+    np.int32, 
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32, 
+    np.uint64,
+    np.float_,
+    np.float16,
+    np.float32, 
+    np.float64,
+    np.complex_,
+    np.complex64,
+    np.complex128
+])
+def test_tril_random_dtype(dtype):
+    """
+    测试在随机输入不同数据类型时，MindSpore和PyTorch的tril接口的支持度。
+    """
+    mindspore.set_context(mode=mindspore.PYNATIVE_MODE, pynative_synchronize=True)
+    flag1 = True
+    flag2 = True
+    input_shape = (3, 3) 
+    input_data = np.random.rand(*input_shape).astype(dtype)
+    k = 0  # 对角线偏移
+    try:
+        # MindSpore部分
+        input_ms = mindspore.Tensor(input_data)
+        result_ms = mindspore.mint.tril(input_ms, k)
+        assert isinstance(result_ms, mindspore.Tensor)
+
+    except Exception as e:
+        print(f"MindSpore出现报错: {e}")
+        flag1 = False
+
+    try:
+        # PyTorch部分
+        input_pt = torch.from_numpy(input_data)
+        result_pt = torch.tril(input_pt, k)
+        assert isinstance(result_pt, torch.Tensor)
+
+    except Exception as e:
+        print(f"Pytorch出现报错: {e}")
+        flag2 = False
+
+    if not flag1 and flag2:
+        pytest.fail("mindspore不支持："+str(dtype))
+    if flag1 and not flag2:
+        pytest.fail("pytorch不支持："+str(dtype))
+    if not flag1 and not flag2:
+        pytest.fail("both mindspore 和 pytorch不支持："+str(dtype))
+
+
+
+@pytest.mark.parametrize("input_shape", [
+    (4, 4), (2, 5)
+])
+def test_tril_fixed_dtype_random_value(input_shape):
+    """
+    测试在固定数据类型，随机输入值的情况下，MindSpore和PyTorch的tril接口输出是否相等。
+    """
+    dtype = np.float32
+    input_data = np.random.rand(*input_shape).astype(dtype)
+    k = -1  # 设定对角线偏移  
+    
+    # MindSpore部分
+    input_ms = mindspore.Tensor(input_data)
+    result_ms = mindspore.mint.tril(input_ms, k)
+
+    # PyTorch部分
+    input_pt = torch.from_numpy(input_data)
+    result_pt = torch.tril(input_pt, k)
+
+    compare_results_ms_pt(result_ms, result_pt)
+
+
+
+
+@pytest.mark.parametrize("random_messy_input", [
+    ([[1,2],[3,4]], 0, TypeError),
+    (mindspore.Tensor([[1,2],[3,4]]), 0.0, TypeError),
+    (mindspore.Tensor([1,2,3,4]), 0, ValueError)
+])
+def test_tril_random_messy_input_error_info(random_messy_input):
+    """
+    测试在随机混乱输入情况下，MindSpore的tril接口报错信息的准确性。
+    TypeError - 如果 input 不是Tensor。
+    TypeError - 如果 diagonal 不是int类型。
+    TypeError - 如果 input 的数据类型既不是数值型也不是bool。
+    ValueError - 如果 input 的秩小于2。
+    """
+    flag = False
+    input_ms = random_messy_input[0]
+    k = random_messy_input[1]
+    try:
+        
+        result_ms = mindspore.mint.tril(input_ms, k)
+        print(result_ms)
+        
+    except Exception as e_ms:
+        assert isinstance(e_ms, random_messy_input[-1])
+        flag = True
+    if not flag:
+        pytest.fail("在预期应捕获异常的情况下，未捕获到任何异常，测试不通过")
+
+
+        
+        
+        
+# 以下测试使用该接口的构造函数/神经网络的准确性
+
+
+
+
+def test_tril_in_neural_network():
+    """
+    测试一个包含split操作的网络示例
+    """
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    # mindspore
+    class SimpleNet_ms(mindspore.nn.Cell):
+        def __init__(self):
+            super(SimpleNet_ms, self).__init__()
+
+        def construct(self, x):
+            split_result = mindspore.mint.tril(x,0)
+            return split_result.sum()
+
+    
+    input_ms = mindspore.Tensor(input_value)
+    net_ms = SimpleNet_ms()
+    result_ms = net_ms(input_ms)
+    
+    # pytorch
+    class SimpleNet_pt(torch.nn.Module):
+        def __init__(self):
+            super(SimpleNet_pt, self).__init__()
+
+        def forward(self, x):
+            split_result = torch.tril(x, 0)
+            return split_result.sum()
+
+    input_pt = torch.from_numpy(input_value)
+    net_pt = SimpleNet_pt()
+    result_pt = net_pt(input_pt)
+
+    assert np.allclose(result_ms.asnumpy(), result_pt.numpy(), atol=1e-3)
+
+
+def test_tril_backward():
+    """
+    测试函数反向 
+    """
+    # 定义简单函数
+    def function_ms(x):
+        return mindspore.mint.tril(x,0).sum()
+    def function_pt(x):
+        return torch.tril(x,0).sum()
+
+    input_value = np.random.rand(4, 4).astype(np.float32)
+
+    input_ms = mindspore.Tensor(input_value, mindspore.float32)
+    grad_ms = mindspore.grad(function_ms)(input_ms)
+
+    input_pt = torch.from_numpy(input_value).float().requires_grad_(True)
+    result_pt = function_pt(input_pt)
+    result_pt.backward()
+    grad_pt = input_pt.grad
+
+    assert np.allclose(grad_ms.asnumpy(), grad_pt.numpy(), atol=1e-3)


### PR DESCRIPTION
相关问题已上传gitee:
[mindspore.mint.narrow()不支持int16,uint16,uint32,uint64,float64,complex128,complex64类型的输入](https://gitee.com/mindspore/mindspore/issues/IBCTE7?from=project-issue)
[mindspore.mint.narrow()在CPU上执行时start超出维度范围后不会报错](https://gitee.com/mindspore/mindspore/issues/IBCTEH?from=project-issue)
[mindspore.mint.nonzero()不支持complex128,complex64类型的输入](https://gitee.com/mindspore/mindspore/issues/IBCTEQ?from=project-issue)
[mindspore.mint.nonzero(input,as_tuple)，as_tuple为字符串类型时不会报错](https://gitee.com/mindspore/mindspore/issues/IBCTFO?from=project-issue)
[mindspore.mint.tile()不支持uint16类型的输入](https://gitee.com/mindspore/mindspore/issues/IBCTFY?from=project-issue)
[mindspore.mint.tril()不支持complex64,complex123类型的输入](https://gitee.com/mindspore/mindspore/issues/IBCTG2?from=project-issue)