### PR TITLE
mindspore.mint接口测试任务2:mindspore.mint.ones_like、mindspore.mint.zeros、mindspore.mint.zeros_like、mindspore.mint.cat、mindspore.mint.gather函数测试代码

### DIFF
--- a/test/test_cat.py
+++ b/test/test_cat.py
@@ -1,0 +1,258 @@
+import pytest
+import random
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+"""
+mindspore.mint.cat(tensors, dim=0)
+    在指定维度上拼接输入Tensor。
+
+参数：
+    tensors (Union[tuple, list]) - 输入为Tensor组成的tuple或list。元素秩相同, 即 R 。 
+    dim (int) - 表示指定的维度，取值范围是 [-R,R)。默认值： 0 。
+
+返回：Tensor，数据类型与 tensors 相同。
+
+异常：
+    TypeError - dim 不是int。
+    ValueError - tensors 是不同维度的Tensor。
+    ValueError - dim 的值不在区间 [-R,R) 内。
+    ValueError - 除了 dim 之外， tensors 的shape不相同。
+    ValueError - tensors 为空tuple或list。
+支持平台：Ascend
+"""
+
+"""
+torch.cat(tensors, dim=0, *, out=None) → Tensor
+    该函数用于在给定维度上连接一系列张量。所有张量必须具有相同的形状（在连接维度上除外），或者是大小为 (0,) 的一维空张量。
+    torch.cat() 可以视为 torch.split() 和 torch.chunk() 的逆操作。
+    通过示例可以更好地理解 torch.cat()。
+
+参数
+    tensors (张量序列) – 任何 Python 张量序列，必须是相同类型的张量。提供的非空张量必须在连接维度上具有相同的形状。
+    dim (int, 可选) – 连接张量的维度。
+关键字参数
+    out (Tensor, 可选) – 输出张量。
+"""
+
+mindspore_dtype_list = [
+    ms.int8,
+    ms.int16, 
+    ms.int32, 
+    ms.int64, 
+    ms.uint8, 
+    ms.uint16,
+    ms.uint32, 
+    ms.uint64,
+    ms.float16, 
+    ms.float32, 
+    ms.float64, 
+    ms.bfloat16,
+    ms.complex64,
+    ms.complex128,
+    ms.bool_
+]
+
+pytorch_dtype_list = [
+    torch.int8,    
+    torch.int16,    
+    torch.int32,   
+    torch.int64,  
+    torch.uint8,    
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.float32,  
+    torch.float64, 
+    torch.float16,  
+    torch.bfloat16, 
+    torch.complex64, 
+    torch.complex128,
+    torch.bool
+]
+
+
+gradient_dtype_list = {
+    ms.float16: torch.float16,
+    ms.float32: torch.float32,
+    ms.float64: torch.float64
+}
+
+
+
+def is_same(shape, dtype_ms=ms.float32, dtype_torch=torch.float32, dim=0):
+    input_x1 = np.random.randn(*shape)
+    input_x2 = np.random.randn(*shape)
+
+    ms_tensor_x1 = Tensor(input_x1, dtype=dtype_ms)
+    ms_tensor_x2 = Tensor(input_x2, dtype=dtype_ms)
+    ms_result = mint.cat([ms_tensor_x1, ms_tensor_x2], dim=dim).numpy()
+
+    torch_tensor_x1 = torch.tensor(input_x1, dtype=dtype_torch)
+    torch_tensor_x2 = torch.tensor(input_x2, dtype=dtype_torch)
+    torch_result = torch.cat([torch_tensor_x1, torch_tensor_x2], dim=dim).numpy()
+
+    return np.allclose(ms_result, torch_result)
+
+def generate_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 [2, 3], [3, 5, 6], [7, 8, 9]。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = [random.randint(min_size, max_size) for _ in range(num_dims)]
+        shapes.append(shape)
+    return shapes
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    input_x1 = np.random.randn(2, 3)
+    input_x2 = np.random.randn(2, 3)
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+
+        err = False
+        try:
+            ms_tensor_x1 = Tensor(input_x1, dtype=dtype_ms)
+            ms_tensor_x2 = Tensor(input_x2, dtype=dtype_ms)
+            ms_result = mint.cat([ms_tensor_x1, ms_tensor_x2], dim=0).numpy()
+        except Exception as e:
+            err = True
+            print(f"mint.cat not supported for {dtype_ms}")
+
+        try:
+            torch_tensor_x1 = torch.tensor(input_x1, dtype=dtype_torch)
+            torch_tensor_x2 = torch.tensor(input_x2, dtype=dtype_torch)
+            torch_result = torch.cat([torch_tensor_x1, torch_tensor_x2], dim=0).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.cat not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shape_list = generate_input_shapes()
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = shape_list[i]
+            for dim in range(-len(shape),len(shape)):
+                result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch, dim=dim)
+                assert result
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    # TypeError - dim 不是int。
+    try:
+        input_x1 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        input_x2 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        output = mint.cat([input_x1, input_x2], dim='a')
+        print(output)
+    except Exception as e:
+        print(f'TypeError - dim 不是int : {e}')
+    # ValueError - tensors 是不同维度的Tensor。
+    try:
+        input_x1 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        input_x2 = Tensor([[0, 1], [2, 1], [2,1]], dtype = ms.float32)
+        output = mint.cat([input_x1, input_x2], dim=1)
+        print(output)
+    except Exception as e:
+        print(f'ValueError - tensors 是不同维度的Tensor : {e}')
+    # ValueError - dim 的值不在区间 [-R,R) 内。
+    try:
+        input_x1 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        input_x2 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        output = mint.cat([input_x1, input_x2], dim=2)
+        print(output)
+    except Exception as e:
+        print(f'ValueError - dim 的值不在区间 [-R,R) 内 : {e}')
+    # ValueError - 除了 dim 之外， tensors 的shape不相同。
+    try:
+        input_x1 = Tensor([[0, 1], [2, 1]], dtype = ms.float32)
+        input_x2 = Tensor([[0, 1, 2], [2, 1, 0]], dtype = ms.float32)
+        output = mint.cat([input_x1, input_x2], dim=0)
+        print(output)
+    except Exception as e:
+        print(f'ValueError - 除了 dim 之外， tensors 的shape不相同 : {e}')
+    # ValueError - tensors 为空tuple或list。
+    try:
+        output = mint.cat([], dim=0)
+        print(output)
+    except Exception as e:
+        print(f'ValueError - tensors 为空tuple或list : {e}')
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    def forward(x, y):
+        return x * y
+    
+    shapes_list = generate_input_shapes()
+    for ms_dtype, torch_dtype in gradient_dtype_list.items():
+        for shape in shapes_list:
+            for dim in range(-len(shape),len(shape)):
+                weight_shape = shape.copy()
+                weight_shape[dim] = weight_shape[dim] * 2
+                weight = np.random.rand(*weight_shape)
+
+                input_x1 = np.random.rand(*shape)
+                input_x2 = np.random.rand(*shape)
+
+                ms_tensor_x1 = Tensor(input_x1, dtype=ms_dtype)
+                ms_tensor_x2 = Tensor(input_x2, dtype=ms_dtype)
+                ms_weight = Tensor(weight, dtype=ms_dtype)
+                ms_result = mint.cat([ms_tensor_x1, ms_tensor_x2], dim=dim)
+                grad_fn = value_and_grad(forward)
+                z_ms, gradient_ms= grad_fn(ms_result, ms_weight)
+
+                torch_tensor_x1 = torch.tensor(input_x1, dtype=torch_dtype, requires_grad=True)
+                torch_tensor_x2 = torch.tensor(input_x2, dtype=torch_dtype, requires_grad=True)
+                torch_weight = torch.tensor(weight, dtype=torch_dtype, requires_grad=True)
+                torch_result = torch.cat([torch_tensor_x1, torch_tensor_x2], dim=dim)
+                torch_result.retain_grad()
+                z_torch = forward(torch_result, torch_weight)
+                loss = z_torch.sum()
+                loss.backward()
+                gradient_torch = torch_result.grad
+
+                assert np.allclose(z_ms.asnumpy(), z_torch.detach().numpy(), atol=1e-3)
+                assert np.allclose(gradient_ms.asnumpy(), gradient_torch.numpy(), atol=1e-3)
+
+
+if __name__ == '__main__':
+    test_any_different_dtypes(ms.GRAPH_MODE)
+    test_any_different_dtypes(ms.PYNATIVE_MODE)
+    test_any_random_input_fixed_dtype(ms.GRAPH_MODE)
+    test_any_random_input_fixed_dtype(ms.PYNATIVE_MODE)
+    test_any_wrong_input(ms.GRAPH_MODE)
+    test_any_wrong_input(ms.PYNATIVE_MODE)
+    test_any_forward_back(ms.GRAPH_MODE)
+    test_any_forward_back(ms.PYNATIVE_MODE)

--- a/test/test_gather.py
+++ b/test/test_gather.py
@@ -1,0 +1,258 @@
+import pytest
+import random
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+"""
+mindspore.mint.gather(input, dim, index)
+    返回输入Tensor在指定 index 索引对应的元素组成的切片。
+
+警告
+    在Ascend后端，以下场景将导致不可预测的行为：
+    正向执行流程中，当 index 的取值不在范围 [-input.shape[dim], input.shape[dim]) 内；
+    反向执行流程中，当 index 的取值不在范围 [0, input.shape[dim]) 内。
+
+参数：
+    input (Tensor) - 待索引切片取值的原始Tensor。
+    dim (int) - 指定要切片的维度索引。取值范围 [-input.rank, input.rank)。
+    index (Tensor) - 指定原始Tensor中要切片的索引。数据类型必须是int32或int64。需要同时满足以下条件：
+    index.rank == input.rank；
+    对于 axis != dim ， index.shape[axis] <= input.shape[axis] ；
+    index 的取值在有效区间 [-input.shape[dim], input.shape[dim]) ；
+返回：
+    Tensor，数据类型与 input 保持一致，shape与 index 保持一致。
+
+异常：
+    ValueError - input 的shape取值非法。
+    ValueError - dim 取值不在有效范围 [-input.rank, input.rank)。
+    ValueError - index 的值不在有效范围。
+    TypeError - index 的数据类型非法。
+
+支持平台：Ascend
+"""
+
+"""
+torch.cat(tensors, dim=0, *, out=None) → Tensor
+    该函数用于在给定维度上连接一系列张量。所有张量必须具有相同的形状（在连接维度上除外），或者是大小为 (0,) 的一维空张量。
+    torch.cat() 可以视为 torch.split() 和 torch.chunk() 的逆操作。
+    通过示例可以更好地理解 torch.cat()。
+
+参数
+    tensors (张量序列) – 任何 Python 张量序列，必须是相同类型的张量。提供的非空张量必须在连接维度上具有相同的形状。
+    dim (int, 可选) – 连接张量的维度。
+关键字参数
+    out (Tensor, 可选) – 输出张量。
+"""
+
+mindspore_dtype_list = [
+    ms.int8,
+    ms.int16, 
+    ms.int32, 
+    ms.int64, 
+    ms.uint8, 
+    ms.uint16,
+    ms.uint32, 
+    ms.uint64,
+    ms.float16, 
+    ms.float32, 
+    ms.float64, 
+    ms.bfloat16,
+    ms.complex64,
+    ms.complex128,
+    ms.bool_
+]
+
+pytorch_dtype_list = [
+    torch.int8,    
+    torch.int16,    
+    torch.int32,   
+    torch.int64,  
+    torch.uint8,    
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.float32,  
+    torch.float64, 
+    torch.float16,  
+    torch.bfloat16, 
+    torch.complex64, 
+    torch.complex128,
+    torch.bool
+]
+
+
+gradient_dtype_list = {
+    ms.float16: torch.float16,
+    ms.float32: torch.float32,
+    ms.float64: torch.float64
+}
+
+
+
+def is_same(shape, dtype_ms=ms.float32, dtype_torch=torch.float32, dim=0):
+    length = shape[dim]
+    np_index = np.random.randint(0, length, size=shape)
+    input_x = np.random.randn(*shape)
+
+    ms_tensor_x = Tensor(input_x, dtype=dtype_ms)
+    ms_index = Tensor(np_index, dtype=ms.int32)
+    ms_result = mint.gather(ms_tensor_x, dim, ms_index).numpy()
+
+    torch_tensor_x = torch.tensor(input_x, dtype=dtype_torch)
+    torch_index = torch.tensor(np_index, dtype=torch.int64)
+    torch_result = torch.gather(torch_tensor_x, dim, torch_index).numpy()
+
+    return np.allclose(ms_result, torch_result, atol=1e-3)
+
+def generate_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 [2, 3], [3, 5, 6], [7, 8, 9]。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = [random.randint(min_size, max_size) for _ in range(num_dims)]
+        shapes.append(shape)
+    return shapes
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    input_x = np.array([[-0.1, 0.3, 3.6], [0.4, 0.5, -3.2]])
+    index = np.array([[0, 1], [1, 1]])
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+
+        err = False
+        try:
+            ms_tensor = Tensor(input_x, dtype=dtype_ms)
+            index_ms = Tensor(index, dtype=ms.int32)
+            ms_result = mint.gather(ms_tensor, 1, index_ms).numpy()
+        except Exception as e:
+            err = True
+            print(f"mint.gather not supported for {dtype_ms}")
+
+        try:
+            torch_tensor = torch.tensor(input_x, dtype=dtype_torch)
+            index_torch = torch.tensor(index, dtype=torch.int32)
+            torch_result = torch.gather(torch_tensor, 1, index_torch).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.gather not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shape_list = generate_input_shapes()
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = shape_list[i]
+            for dim in range(-len(shape),len(shape)):
+                result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch, dim=dim)
+                assert result
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms_dtype = ms.float32
+    # ValueError - input 的shape取值非法。
+    try:
+        input_tensor = Tensor(np.array([[-0.1, 0.3, 3.6], [0.4, 0.5, -3.2]]), dtype = ms_dtype)
+        index = Tensor(np.array([[0, 0], [1, 1], [2, 1]]), dtype = mindspore.int32)
+        output = mint.gather(input_tensor, 1, index)
+    except Exception as e:
+        print(f"ValueError - input 的shape取值非法: {e}.")
+    # ValueError - dim 取值不在有效范围 [-input.rank, input.rank)。
+    try:
+        input_tensor = Tensor(np.array([[-0.1, 0.3, 3.6], [0.4, 0.5, -3.2]]), dtype = ms_dtype)
+        index = Tensor(np.array([[0, 0], [1, 1]]), dtype = mindspore.int32)
+        output = mint.gather(input_tensor, 2, index)
+    except Exception as e:
+        print(f"ValueError - dim 取值不在有效范围 [-input.rank, input.rank): {e}.")
+    # ValueError - index 的值不在有效范围。
+    try:
+        input_tensor = Tensor(np.array([[-0.1, 0.3, 3.6], [0.4, 0.5, -3.2]]), dtype = ms_dtype)
+        index = Tensor(np.array([[0, 0], [1, 4]]), dtype = mindspore.int32)
+        output = mint.gather(input_tensor, 1, index)
+        print(output)
+    except Exception as e:
+        print(f"ValueError - index 的值不在有效范围: {e}.")
+    # TypeError - index 的数据类型非法。
+    try:
+        input_tensor = Tensor(np.array([[-0.1, 0.3, 3.6], [0.4, 0.5, -3.2]]), dtype = ms_dtype)
+        index = Tensor(np.array([[0, 0], [1, 1]]), dtype = mindspore.float32)
+        output = mint.gather(input_tensor, 1, index)
+    except Exception as e:
+        print(f"TypeError - index 的数据类型非法: {e}.")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    def forward(x, y):
+        return x * y
+    
+    shapes_list = generate_input_shapes()
+    for ms_dtype, torch_dtype in gradient_dtype_list.items():
+        for shape in shapes_list:
+            for dim in range(-len(shape),len(shape)):
+                length = shape[dim]
+                np_index = np.random.randint(0, length, size=shape)
+                input_x = np.random.rand(*shape)
+                weight = np.random.rand(*shape)
+
+                ms_tensor_x1 = Tensor(input_x, dtype=ms_dtype)
+                ms_index = Tensor(np_index, dtype=ms.int32)
+                ms_weight = Tensor(weight, dtype=ms_dtype)
+                ms_result = mint.gather(ms_tensor_x1, dim, ms_index)
+                grad_fn = value_and_grad(forward)
+                z_ms, gradient_ms= grad_fn(ms_result, ms_weight)
+
+                torch_tensor_x = torch.tensor(input_x, dtype=torch_dtype, requires_grad=True)
+                torch_index = torch.tensor(np_index, dtype=torch.int64)
+                torch_weight = torch.tensor(weight, dtype=torch_dtype, requires_grad=True)
+                torch_result = torch.gather(torch_tensor_x, dim, torch_index)
+                torch_result.retain_grad()
+                z_torch = forward(torch_result, torch_weight)
+                loss = z_torch.sum()
+                loss.backward()
+                gradient_torch = torch_result.grad
+
+                assert np.allclose(z_ms.asnumpy(), z_torch.detach().numpy(), atol=1e-3)
+                assert np.allclose(gradient_ms.asnumpy(), gradient_torch.numpy(), atol=1e-3)
+
+
+if __name__ == '__main__':
+    test_any_different_dtypes(ms.GRAPH_MODE)
+    test_any_different_dtypes(ms.PYNATIVE_MODE)
+    test_any_random_input_fixed_dtype(ms.GRAPH_MODE)
+    test_any_random_input_fixed_dtype(ms.PYNATIVE_MODE)
+    test_any_wrong_input(ms.GRAPH_MODE)
+    test_any_wrong_input(ms.PYNATIVE_MODE)
+    test_any_forward_back(ms.GRAPH_MODE)
+    test_any_forward_back(ms.PYNATIVE_MODE)

--- a/test/test_ones_like.py
+++ b/test/test_ones_like.py
@@ -1,0 +1,207 @@
+import pytest
+import random
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+"""
+mindspore.mint.ones_like(input, *, dtype=None)
+创建一个数值全为1的Tensor，shape和 input 相同，dtype由 dtype 决定。
+如果 dtype = None，输出Tensor的数据类型会和 input 一致。
+
+参数：input (Tensor) - 任意维度的Tensor。
+关键字参数：dtype (mindspore.dtype, 可选) - 用来描述所创建的Tensor的 dtype。如果为 None ，那么将会使用 input 的dtype。默认值： None 。
+返回：Tensor，具有与 input 相同的shape并填充了1。
+异常：TypeError - input 不是Tensor。
+"""
+
+"""
+torch.ones_like()是 PyTorch 中用于创建与给定张量具有相同形状和数据类型的全为 1 的张量的函数。
+用法
+    torch.ones_like(input_tensor, dtype=None, layout=None, device=None, requires_grad=False)
+参数
+    input_tensor: 输入张量，ones_like 将根据此张量的形状和数据类型创建新的张量。
+    dtype (可选): 指定返回张量的数据类型。如果未指定，默认使用 input_tensor 的数据类型。
+    layout (可选): 指定张量的布局（例如，稀疏或稠密）。默认值为 torch.strided。
+    device (可选): 指定张量的设备（如 CPU 或 GPU）。默认与 input_tensor 相同。
+    requires_grad (可选): 如果设置为 True，则在计算图中跟踪该张量的操作。默认值为 False。
+"""
+
+mindspore_dtype_list = [
+    ms.int8,
+    ms.int16, 
+    ms.int32, 
+    ms.int64, 
+    ms.uint8, 
+    ms.uint16,
+    ms.uint32, 
+    ms.uint64,
+    ms.float16, 
+    ms.float32, 
+    ms.float64, 
+    ms.bfloat16,
+    ms.complex64,
+    ms.complex128,
+    ms.bool_
+]
+
+pytorch_dtype_list = [
+    torch.int8,    
+    torch.int16,    
+    torch.int32,   
+    torch.int64,  
+    torch.uint8,    
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.float32,  
+    torch.float64, 
+    torch.float16,  
+    torch.bfloat16, 
+    torch.complex64, 
+    torch.complex128,
+    torch.bool
+]
+
+
+gradient_dtype_list = {
+    ms.float16: torch.float16,
+    ms.float32: torch.float32,
+    ms.float64: torch.float64
+}
+
+
+
+def is_same(input_data=[[1,0],[0,0],[1,1]], shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_data = np.random.randn(*shape)
+
+    ms_tensor = Tensor(input_data, dtype=dtype_ms)
+    torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+    ms_result = mint.ones_like(ms_tensor, dtype=dtype_ms).numpy()
+    torch_result = torch.ones_like(torch_tensor, dtype=dtype_torch).numpy()
+
+    return np.allclose(ms_result, torch_result, atol=1e-3)
+
+def generate_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 [2, 3], [3, 5, 6], [7, 8, 9]。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = [random.randint(min_size, max_size) for _ in range(num_dims)]
+        shapes.append(shape)
+    return shapes
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    input_data = np.random.randn(2, 3)
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+
+        ms_tensor = Tensor(input_data, dtype=dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.ones_like(ms_tensor, dtype=dtype_ms).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.ones_like not supported for {dtype_ms}")
+
+        try:
+            torch_result = torch.ones_like(torch_tensor, dtype=dtype_torch).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.ones_like not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shape_list = generate_input_shapes()
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = shape_list[i]
+            result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+            assert result
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    # 异常：TypeError - input 不是Tensor。
+    try:
+        input_tensor = "wrong_input"
+        ms_tensor = mint.ones_like(input_tensor, dtype=ms.float32)
+    except Exception as e:
+        print(f"Error with wrong input: {e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    def forward(x, y):
+        return x * y
+    
+    shapes_list = generate_input_shapes()
+    for ms_dtype, torch_dtype in gradient_dtype_list.items():
+        for shape in shapes_list:
+            x_data = np.random.randn(*shape)
+            weight = np.random.rand(*shape)
+
+            ms_tensor = Tensor(x_data, dtype=ms_dtype)
+            x_ms = mint.ones_like(ms_tensor, dtype=ms_dtype)
+            y_ms = Tensor(weight, ms_dtype)
+            grad_fn = value_and_grad(forward)
+            z_ms, gradient_ms= grad_fn(x_ms, y_ms)
+
+            torch_tensor = torch.tensor(x_data, dtype=torch_dtype)
+            x_torch = torch.ones_like(torch_tensor, dtype=torch_dtype, requires_grad=True)
+            y_torch = torch.tensor(weight, dtype=torch_dtype, requires_grad=True)
+            z_torch = forward(x_torch, y_torch)
+            loss = z_torch.sum()
+            loss.backward()
+            gradient_torch = x_torch.grad
+
+            assert np.allclose(z_ms.asnumpy(), z_torch.detach().numpy(), atol=1e-3)
+            assert np.allclose(gradient_ms.asnumpy(), gradient_torch.numpy(), atol=1e-3)
+
+
+if __name__ == '__main__':
+    test_any_different_dtypes(ms.GRAPH_MODE)
+    test_any_different_dtypes(ms.PYNATIVE_MODE)
+    test_any_random_input_fixed_dtype(ms.GRAPH_MODE)
+    test_any_random_input_fixed_dtype(ms.PYNATIVE_MODE)
+    test_any_wrong_input(ms.GRAPH_MODE)
+    test_any_wrong_input(ms.PYNATIVE_MODE)
+    test_any_forward_back(ms.GRAPH_MODE)
+    test_any_forward_back(ms.PYNATIVE_MODE)
+
+        

--- a/test/test_zeros.py
+++ b/test/test_zeros.py
@@ -1,0 +1,248 @@
+import pytest
+import random
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+"""
+mindspore.mint.zeros(size, *, dtype=None)
+创建一个值全为0的Tensor。第一个参数 size 指定Tensor的shape，第二个参数 dtype 指定填充值的数据类型。
+
+参数：size (Union[tuple[int], list[int], int, Tensor]) - 用来描述所创建的Tensor的shape，只允许正整数或者包含正整数的tuple、list、Tensor。 
+如果是一个Tensor，必须是一个数据类型为int32或者int64的0-D或1-D Tensor。
+关键字参数：dtype (mindspore.dtype, 可选) - 用来描述所创建的Tensor的dtype。如果为 None ，那么将会使用mindspore.float32。默认值： None 。
+返回：Tensor，dtype和shape由入参决定。
+异常：TypeError - 如果 size 不是一个int，或元素为int的元组、列表、Tensor。
+"""
+
+"""
+torch.zeros(*size, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) → Tensor
+    返回一个填充了标量值 0 的张量，形状由变量参数 size 定义。
+
+参数
+    size (int...)：一个整数序列，定义输出张量的形状。可以是可变数量的参数，也可以是列表或元组等集合。
+关键字参数
+    out (Tensor, 可选)：输出张量。
+    dtype (torch.dtype, 可选)：返回张量的期望数据类型。默认值：如果为 None，则使用全局默认值（见 torch.set_default_dtype()）。
+    layout (torch.layout, 可选)：返回张量的期望布局。默认值：torch.strided。
+    device (torch.device, 可选)：返回张量的期望设备。默认值：如果为 None，则使用默认张量类型的当前设备（见 torch.set_default_device()）。对于 CPU 张量类型，设备将是 CPU；对于 CUDA 张量类型，设备将是当前的 CUDA 设备。
+    requires_grad (bool, 可选)：如果自动求导应记录对返回张量的操作。默认值：False。
+"""
+
+mindspore_dtype_list = [
+    ms.int8,
+    ms.int16, 
+    ms.int32, 
+    ms.int64, 
+    ms.uint8, 
+    ms.uint16,
+    ms.uint32, 
+    ms.uint64,
+    ms.float16, 
+    ms.float32, 
+    ms.float64, 
+    ms.bfloat16,
+    ms.complex64,
+    ms.complex128,
+    ms.bool_
+]
+
+pytorch_dtype_list = [
+    torch.int8,    
+    torch.int16,    
+    torch.int32,   
+    torch.int64,  
+    torch.uint8,    
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.float32,  
+    torch.float64, 
+    torch.float16,  
+    torch.bfloat16, 
+    torch.complex64, 
+    torch.complex128,
+    torch.bool
+]
+
+
+gradient_dtype_list = {
+    ms.float16: torch.float16,
+    ms.float32: torch.float32,
+    ms.float64: torch.float64
+}
+
+
+
+def is_same(shape, dtype_ms=ms.float32, dtype_torch=torch.float32):
+
+    ms_result = mint.zeros(shape, dtype=dtype_ms).numpy()
+    torch_result = torch.zeros(shape, dtype=dtype_torch).numpy()
+
+    return np.allclose(ms_result, torch_result, atol=1e-3)
+
+def generate_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 [2, 3], [3, 5, 6], [7, 8, 9]。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = [random.randint(min_size, max_size) for _ in range(num_dims)]
+        shapes.append(shape)
+    return shapes
+
+def generate_tuple_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 (2, 3), (3, 5, 6), (7, 8, 9)。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状元组列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = tuple(random.randint(min_size, max_size) for _ in range(num_dims))
+        shapes.append(shape)
+    return shapes
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    shape = generate_input_shapes()[3]
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+
+        err = False
+        try:
+            ms_result = mint.zeros(shape, dtype=dtype_ms).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.zeros not supported for {dtype_ms}")
+
+        try:
+            torch_result = torch.zeros(shape, dtype=dtype_torch).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.zeros not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    # size (list[int])
+    shape_list = generate_input_shapes()
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = shape_list[i]
+            result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+            assert result
+    
+    # size (tuple[int])
+    tuple_shape_list = generate_tuple_input_shapes()
+    for i in range(len(tuple_shape_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = tuple_shape_list[i]
+            result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+            assert result
+    
+    # size (int)
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        shape = np.random.randint(1, 1000)
+        result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+        assert result
+    
+    # size (Tensor) 
+    for i in range(len(mindspore_dtype_list)):
+        if mindspore_dtype_list[i] != ms.int32 or mindspore_dtype_list[i] != ms.int64:
+            continue
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        shape = np.random.randint(1, 32)
+        shape_tensor = np.random.rand(shape)
+        ms_tensor = Tensor(shape_tensor, dtype=dtype_ms)
+        result = is_same(shape=ms_tensor, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+        assert result
+
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    # 异常：TypeError - input 不是Tensor。
+    try:
+        input_tensor = "wrong_input"
+        ms_tensor = mint.zeros(input_tensor, dtype=ms.float32)
+    except Exception as e:
+        print(f"Error with wrong input: {e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    def forward(x, y):
+        return x * y
+    
+    shapes_list = generate_input_shapes()
+    for ms_dtype, torch_dtype in gradient_dtype_list.items():
+        for shape in shapes_list:
+            weight = np.random.rand(*shape)
+
+            x_ms = mint.zeros(shape, dtype=ms_dtype)
+            y_ms = Tensor(weight, ms_dtype)
+            grad_fn = value_and_grad(forward)
+            z_ms, gradient_ms= grad_fn(x_ms, y_ms)
+
+            x_torch = torch.zeros(shape, dtype=torch_dtype, requires_grad=True)
+            y_torch = torch.tensor(weight, dtype=torch_dtype, requires_grad=True)
+            z_torch = forward(x_torch, y_torch)
+            loss = z_torch.sum()
+            loss.backward()
+            gradient_torch = x_torch.grad
+
+            assert np.allclose(z_ms.asnumpy(), z_torch.detach().numpy(), atol=1e-3)
+            assert np.allclose(gradient_ms.asnumpy(), gradient_torch.numpy(), atol=1e-3)
+
+
+if __name__ == '__main__':
+    test_any_different_dtypes(ms.GRAPH_MODE)
+    test_any_different_dtypes(ms.PYNATIVE_MODE)
+    test_any_random_input_fixed_dtype(ms.GRAPH_MODE)
+    test_any_random_input_fixed_dtype(ms.PYNATIVE_MODE)
+    test_any_wrong_input(ms.GRAPH_MODE)
+    test_any_wrong_input(ms.PYNATIVE_MODE)
+    test_any_forward_back(ms.GRAPH_MODE)
+    test_any_forward_back(ms.PYNATIVE_MODE)
+
+        

--- a/test/test_zeros_like.py
+++ b/test/test_zeros_like.py
@@ -1,0 +1,210 @@
+import pytest
+import random
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+"""
+mindspore.mint.zeros_like(input, *, dtype=None)
+创建一个数值全为0的Tensor，shape和 input 相同，dtype由 dtype 决定。
+如果 dtype = None，输出Tensor的数据类型会和 input 一致。
+
+参数：input (Tensor) - 用来描述所创建的Tensor的shape。
+关键字参数：dtype (mindspore.dtype, 可选) - 用来描述所创建的Tensor的 dtype。如果为 None ，那么将会使用 input 的dtype。默认值： None 。
+返回：返回一个用0填充的Tensor。
+异常：TypeError - 如果 dtype 不是MindSpore的dtype。
+"""
+
+"""
+torch.zeros_like(input, *, dtype=None, layout=None, device=None, requires_grad=False, memory_format=torch.preserve_format) → Tensor
+
+返回一个填充了标量值 0 的张量，其大小与输入张量相同。torch.zeros_like(input) 等效于 torch.zeros(input.size(), dtype=input.dtype, layout=input.layout, device=input.device)。
+
+参数
+    input (Tensor): 输入张量的大小将决定输出张量的大小。
+关键字参数
+    dtype (torch.dtype, 可选): 返回张量的期望数据类型。默认值：如果为 None，则默认为输入张量的 dtype。
+    layout (torch.layout, 可选): 返回张量的期望布局。默认值：如果为 None，则默认为输入张量的布局。
+    device (torch.device, 可选): 返回张量的期望设备。默认值：如果为 None，则默认为输入张量的设备。
+    requires_grad (bool, 可选): 如果需要自动求导记录在返回张量上的操作。默认值：False。
+    memory_format (torch.memory_format, 可选): 返回张量的期望内存格式。默认值：torch.preserve_format。
+"""
+
+mindspore_dtype_list = [
+    ms.int8,
+    ms.int16, 
+    ms.int32, 
+    ms.int64, 
+    ms.uint8, 
+    ms.uint16,
+    ms.uint32, 
+    ms.uint64,
+    ms.float16, 
+    ms.float32, 
+    ms.float64, 
+    ms.bfloat16,
+    ms.complex64,
+    ms.complex128,
+    ms.bool_
+]
+
+pytorch_dtype_list = [
+    torch.int8,    
+    torch.int16,    
+    torch.int32,   
+    torch.int64,  
+    torch.uint8,    
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.float32,  
+    torch.float64, 
+    torch.float16,  
+    torch.bfloat16, 
+    torch.complex64, 
+    torch.complex128,
+    torch.bool
+]
+
+
+gradient_dtype_list = {
+    ms.float16: torch.float16,
+    ms.float32: torch.float32,
+    ms.float64: torch.float64
+}
+
+
+
+def is_same(input_data=[[1,0],[0,0],[1,1]], shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_data = np.random.randn(*shape)
+
+    ms_tensor = Tensor(input_data, dtype=dtype_ms)
+    torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+    ms_result = mint.zeros_like(ms_tensor, dtype=dtype_ms).numpy()
+    torch_result = torch.zeros_like(torch_tensor, dtype=dtype_torch).numpy()
+
+    return np.allclose(ms_result, torch_result, atol=1e-3)
+
+def generate_input_shapes(min_dims=1, max_dims=7, min_size=1, max_size=10):
+    """
+    生成随机的输入形状，如 [2, 3], [3, 5, 6], [7, 8, 9]。
+
+    参数:
+    - min_dims: 最小维度
+    - max_dims: 最大维度
+    - min_size: 每个维度的最小大小
+    - max_size: 每个维度的最大大小
+
+    返回:
+    - shapes: 生成的输入形状列表
+    """
+    shapes = []
+    for num_dims in range(min_dims, max_dims + 1):
+        shape = [random.randint(min_size, max_size) for _ in range(num_dims)]
+        shapes.append(shape)
+    return shapes
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    input_data = np.random.randn(2, 3)
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+
+        ms_tensor = Tensor(input_data, dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.zeros_like(ms_tensor, dtype=dtype_ms).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.zeros_like not supported for {dtype_ms}")
+
+        try:
+            torch_result = torch.zeros_like(torch_tensor, dtype=dtype_torch).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.zeros_like not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shape_list = generate_input_shapes()
+    for i in range(len(mindspore_dtype_list)):
+        dtype_ms = mindspore_dtype_list[i]
+        dtype_torch = pytorch_dtype_list[i]
+        for i in range(len(shape_list)):
+            shape = shape_list[i]
+            result = is_same(shape=shape, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+            assert result
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    # 异常：TypeError - input 不是Tensor。
+    try:
+        input_tensor = "wrong_input"
+        ms_tensor = mint.zeros_like(input_tensor, dtype=ms.float32)
+    except Exception as e:
+        print(f"Error with wrong input: {e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_any_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    def forward(x, y):
+        return x * y
+    
+    shapes_list = generate_input_shapes()
+    for ms_dtype, torch_dtype in gradient_dtype_list.items():
+        for shape in shapes_list:
+            x_data = np.random.randn(*shape)
+            weight = np.random.rand(*shape)
+
+            ms_tensor = Tensor(x_data, dtype=ms_dtype)
+            x_ms = mint.zeros_like(ms_tensor, dtype=ms_dtype)
+            y_ms = Tensor(weight, ms_dtype)
+            grad_fn = value_and_grad(forward)
+            z_ms, gradient_ms= grad_fn(x_ms, y_ms)
+
+            torch_tensor = torch.tensor(x_data, dtype=torch_dtype)
+            x_torch = torch.zeros_like(torch_tensor, dtype=torch_dtype, requires_grad=True)
+            y_torch = torch.tensor(weight, dtype=torch_dtype, requires_grad=True)
+            z_torch = forward(x_torch, y_torch)
+            loss = z_torch.sum()
+            loss.backward()
+            gradient_torch = x_torch.grad
+
+            assert np.allclose(z_ms.asnumpy(), z_torch.detach().numpy(), atol=1e-3)
+            assert np.allclose(gradient_ms.asnumpy(), gradient_torch.numpy(), atol=1e-3)
+
+
+if __name__ == '__main__':
+    test_any_different_dtypes(ms.GRAPH_MODE)
+    test_any_different_dtypes(ms.PYNATIVE_MODE)
+    test_any_random_input_fixed_dtype(ms.GRAPH_MODE)
+    test_any_random_input_fixed_dtype(ms.PYNATIVE_MODE)
+    test_any_wrong_input(ms.GRAPH_MODE)
+    test_any_wrong_input(ms.PYNATIVE_MODE)
+    test_any_forward_back(ms.GRAPH_MODE)
+    test_any_forward_back(ms.PYNATIVE_MODE)
+
+        


### PR DESCRIPTION
【任务背景】
mindspore.mint.ones_like、mindspore.mint.zeros、mindspore.mint.zeros_like、mindspore.mint.cat、mindspore.mint.gather
【需求描述】
1.对应Pytorch 的相应接口进行测试：
a) 测试random输入不同dtype，对比两个框架的支持度
b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
d) 测试随机混乱输入，报错信息的准确性
2. 测试使用接口构造函数/神经网络的准确性
a) Github搜索带有该接口的代码片段/神经网络
b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度