### PR TITLE
mindspore.mint接口测试任务5-mint.normal(), mint.rand_like(), mint.stack(), mint.triu(), mint.where()

### DIFF
--- a/test/test_normal.py
+++ b/test/test_normal.py
@@ -1,0 +1,178 @@
+import mindspore as ms
+import numpy as np
+from mindspore import mint, Tensor, ops, Parameter
+import torch
+
+#normal:根据正态（高斯）随机数分布生成随机数。
+
+#1.对应Pytorch 的相应接口进行测试：
+#a) 测试random输入不同dtype，对比两个框架的支持度
+def test_normal_dtype():
+    print("--->This function: test mindspore.mint.normal [dtype]<---")
+
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            mean_np = np.random.choice(np.array([True, False]), size=3)
+            std_np = np.random.choice(np.array([True, False]), size=3)
+            mean_torch = torch.from_numpy(mean_np)
+            std_torch = torch.from_numpy(std_np)
+            mean_ms = Tensor.from_numpy(mean_np)
+            std_ms = Tensor.from_numpy(std_np)
+        elif dtype == 'bfloat16':
+            mean_np = np.random.rand(3).astype(np.float32)
+            std_np = np.random.rand(3).astype(np.float32)
+            mean_torch = torch.from_numpy(mean_np).type(torch.bfloat16)
+            std_torch = torch.from_numpy(std_np).type(torch.bfloat16)
+            mean_ms = Tensor.from_numpy(mean_np).astype(ms.bfloat16)
+            std_ms = Tensor.from_numpy(std_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            mean_np = np.random.rand(3).astype(dtype)
+            std_np = np.random.rand(3).astype(dtype)
+            mean_torch = torch.from_numpy(mean_np)
+            std_torch = torch.from_numpy(std_np)
+            mean_ms = Tensor.from_numpy(mean_np)
+            std_ms = Tensor.from_numpy(std_np)
+        else:
+            mean_np = np.random.randint(0, 10, size=3, dtype=dtype)
+            std_np = np.random.randint(0, 10, size=3, dtype=dtype)
+            mean_torch = torch.from_numpy(mean_np)
+            std_torch = torch.from_numpy(std_np)
+            mean_ms = Tensor.from_numpy(mean_np)
+            std_ms = Tensor.from_numpy(std_np)
+        
+        torch_support = True
+        ms_support = True
+        #test
+        try:
+            normal_torch = torch.normal(mean=mean_torch, std=std_torch)
+            print(f"<torch_result>: {normal_torch}")
+        except:
+            torch_support = False
+
+        try:
+            normal_ms = mint.normal(mean=mean_ms, std=std_ms)
+            print(f"<torch_result>: {normal_ms}")
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[dtype] BOTH SUPPORT (from test_normal_dtype): "
+                  f"torch.normal support {normal_torch.dtype} "
+                  f"& mindspore.mint.normal support {normal_ms.dtype}.")
+        elif torch_support == ms_support == False:
+            print(f"[dtype] BOTH NOT SUPPORT (from test_normal_dtype): "
+                  f"torch.normal does not support {mean_torch.dtype} "
+                  f"& mindspore.mint.normal does not support {mean_ms.dtype}.")
+        elif torch_support == True and ms_support == False:
+            print(f"[dtype] ONLY TORCH (from test_normal_dtype): "
+                  f"torch.normal support {normal_torch.dtype} "
+                  f"but mindspore.mint.normal NOT.")
+        else:
+            print(f"[dtype] ONLY MS (from test_normal_dtype): "
+                  f"mindspore.mint.normal support {normal_ms.dtype} "
+                  f"but torch.normal NOT.")
+
+        print('='*50)
+
+#b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
+def test_normal_output():
+    print("--->This function: test mindspore.mint.normal [output]<---")
+    #函数本身是随机生成，无法进行误差比较
+
+#c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
+def test_normal_paramType():
+    
+    print("--->This function: test mindspore.mint.normal [paramType]<---")
+
+    #normal的size参数只在mean和std都为常量float时起作用
+    mean = 1.0
+    std = 2.0
+
+    params = (("abc", 'string'), 
+              (True, 'bool'), 
+              (0, 'int'), 
+              (1.0, 'float'), 
+              ([1, 2], 'list'),
+              ((1, 2), 'tuple'),
+              )
+
+    for (param, param_type) in params:
+        #test
+        torch_support = True
+        ms_support = True
+
+        try:
+            normal_torch = torch.normal(mean=mean, std=std, size=param)
+        except:
+            torch_support = False
+
+        try:
+            normal_ms = mint.normal(mean=mean, std=std, size=param)
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[paramType: {param_type}] BOTH SUPPORT(from test_normal_paramType).")
+        elif torch_support == ms_support == False:
+            print(f"[paramType: {param_type}] BOTH NOT SUPPORT(from test_normal_paramType).")
+        elif torch_support == True and ms_support == False:
+            print(f"[paramType: {param_type}] ONLY TORCH(from test_normal_paramType): "
+                  "torch.normal support but mindspore.mint.normal NOT.")
+        else:
+            print(f"[paramType: {param_type}] ONLY MS(from test_normal_paramType): "
+                  "mindspore.mint.normal support but torch.normal NOT.")
+
+        print('='*50)
+
+#d) 测试随机混乱输入，报错信息的准确性
+def test_normal_errorMessage():
+    print("--->This function: test mindspore.mint.normal [errorMessage]<---")
+    
+    #input mean TypeError
+    try:
+        mean_ms1 = True
+        std_np1 = np.random.rand(3).astype(np.float32)
+        std_ms1 = Tensor.from_numpy(std_np1)
+        normal_ms1 = mint.normal(mean=mean_ms1, std=std_ms1)
+        print(normal_ms1)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_normal_errorMessage): "
+              "Test Target: input mean type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+    #input std TypeError
+    try:
+        mean_np2 = np.random.rand(3).astype(np.float32)
+        mean_ms2 = Tensor.from_numpy(mean_np2)
+        std_ms2 = True
+        normal_ms2 = mint.normal(mean=mean_ms2, std=std_ms2)
+        print(normal_ms2)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_normal_errorMessage): "
+              "Test Target: input std type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+#2. 测试使用接口构造函数/神经网络的准确性
+#a) Github搜索带有该接口的代码片段/神经网络
+#b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
+#c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度
+
+#函数本身随机，无法测试第二部分内容
+
+
+if __name__ == '__main__':
+    test_normal_dtype()
+    test_normal_output()
+    test_normal_paramType()
+    test_normal_errorMessage()

--- a/test/test_rand_like.py
+++ b/test/test_rand_like.py
@@ -1,0 +1,152 @@
+import mindspore as ms
+import numpy as np
+from mindspore import mint, Tensor, ops, Parameter
+import torch
+
+#rand_like:返回shape与输入相同，类型为 dtype 的Tensor，dtype由输入决定，其元素取值服从区间内的均匀分布。
+
+#1.对应Pytorch 的相应接口进行测试：
+#a) 测试random输入不同dtype，对比两个框架的支持度
+def test_rand_like_dtype():
+    print("--->This function: test mindspore.mint.rand_like [dtype]<---")
+
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            input_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        elif dtype == 'bfloat16':
+            input_np = np.random.rand(3, 3).astype(np.float32)
+            input_torch = torch.from_numpy(input_np).type(torch.bfloat16)
+            input_ms = Tensor.from_numpy(input_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np = np.random.rand(3, 3).astype(dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        else:
+            input_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+
+        torch_support = True
+        ms_support = True
+        #test
+        try:
+            rand_like_torch = torch.rand_like(input_torch)
+            print(f"<torch_result>: {rand_like_torch}")
+        except:
+            torch_support = False
+
+        try:
+            rand_like_ms = mint.rand_like(input_ms)
+            print(f"<torch_result>: {rand_like_ms}")
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[dtype] BOTH SUPPORT (from test_rand_like_dtype): "
+                  f"torch.rand_like support {rand_like_torch.dtype} "
+                  f"& mindspore.mint.rand_like support {rand_like_ms.dtype}.")
+        elif torch_support == ms_support == False:
+            print(f"[dtype] BOTH NOT SUPPORT (from test_rand_like_dtype): "
+                  f"torch.rand_like does not support {input_torch.dtype} "
+                  f"& mindspore.mint.rand_like does not support {input_ms.dtype}.")
+        elif torch_support == True and ms_support == False:
+            print(f"[dtype] ONLY TORCH (from test_rand_like_dtype): "
+                  f"torch.rand_like support {rand_like_torch.dtype} "
+                  f"but mindspore.mint.rand_like NOT.")
+        else:
+            print(f"[dtype] ONLY MS (from test_rand_like_dtype): "
+                  f"mindspore.mint.rand_like support {rand_like_ms.dtype} "
+                  f"but torch.rand_like NOT.")
+
+        print('='*50)
+
+#b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
+def test_rand_like_output():
+    print("--->This function: test mindspore.mint.rand_like [output]<---")
+    #函数本身是随机生成，无法进行误差比较
+
+#c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
+def test_rand_like_paramType():
+    print("--->This function: test mindspore.mint.rand_like [paramType]<---")
+
+    input_np = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).astype(np.float32)
+
+    input_torch = torch.from_numpy(input_np)
+    input_ms = Tensor.from_numpy(input_np)
+    #只能dtype类型
+    params = (("abc", 'string'), 
+              (True, 'bool'), 
+              (0, 'int'), 
+              (1.0, 'float'), 
+              ([1, 2], 'list'),
+              ((0, 1), 'tuple')
+              )
+
+    for (param, param_type) in params:
+        #test
+        torch_support = True
+        ms_support = True
+        try:
+            rand_like_torch = torch.rand_like(input=input_torch, dtype=param)
+        except:
+            torch_support = False
+
+        try:
+            rand_like_ms = mint.rand_like(input=input_ms, dtype=param)
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[paramType: {param_type}] BOTH SUPPORT(from test_rand_like_paramType).")
+        elif torch_support == ms_support == False:
+            print(f"[paramType: {param_type}] BOTH NOT SUPPORT(from test_rand_like_paramType).")
+        elif torch_support == True and ms_support == False:
+            print(f"[paramType: {param_type}] ONLY TORCH(from test_rand_like_paramType): "
+                  "torch.rand_like support but mindspore.mint.rand_like NOT.")
+        else:
+            print(f"[paramType: {param_type}] ONLY MS(from test_rand_like_paramType): "
+                  "mindspore.mint.rand_like support but torch.rand_like NOT.")
+
+        print('='*50)
+
+#d) 测试随机混乱输入，报错信息的准确性
+def test_rand_like_errorMessage():
+    print("--->This function: test mindspore.mint.rand_like [errorMessage]<---")
+
+    #dtype ValueError
+    try:
+        input_np1 = np.random.rand(3, 3).astype(np.float32)
+        input_ms1 = Tensor.from_numpy(input_np1)
+        dtype = ms.int32
+        rand_like_ms1 = mint.rand_like(input=input_ms1, dtype=dtype)
+        print(rand_like_ms1)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_rand_like_errorMessage): "
+              "Test Target: dtype error-ValueError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+
+#2. 测试使用接口构造函数/神经网络的准确性
+#a) Github搜索带有该接口的代码片段/神经网络
+#b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
+#c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度
+
+#函数本身随机，无法测试第二部分内容
+
+if __name__ == '__main__':
+    test_rand_like_dtype()
+    test_rand_like_output()
+    test_rand_like_paramType()
+    test_rand_like_errorMessage()

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -1,0 +1,293 @@
+import mindspore as ms
+import numpy as np
+from mindspore import mint, Tensor, ops, Parameter
+import torch
+
+#stack:在指定轴上对输入Tensor序列进行堆叠。
+
+#1.对应Pytorch 的相应接口进行测试：
+#a) 测试random输入不同dtype，对比两个框架的支持度
+def test_stack_dtype():
+    print("--->This function: test mindspore.mint.stack [dtype]<---")
+
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            input_np1 = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_np2 = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+        elif dtype == 'bfloat16':
+            input_np1 = np.random.rand(3, 3).astype(np.float32)
+            input_np2 = np.random.rand(3, 3).astype(np.float32)
+            input_torch1 = torch.from_numpy(input_np1).type(torch.bfloat16)
+            input_ms1 = Tensor.from_numpy(input_np1).astype(ms.bfloat16)
+            input_torch2 = torch.from_numpy(input_np2).type(torch.bfloat16)
+            input_ms2 = Tensor.from_numpy(input_np2).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np1 = np.random.rand(3, 3).astype(dtype)
+            input_np2 = np.random.rand(3, 3).astype(dtype)
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+        else:
+            input_np1 = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_np2 = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+
+        torch_support = True
+        ms_support = True
+        #test
+        try:
+            stack_torch = torch.stack([input_torch1, input_torch2], dim=0)
+            print(f"<torch_result>: {stack_torch}")
+        except:
+            torch_support = False
+
+        try:
+            stack_ms = mint.stack([input_ms1, input_ms2], dim=0)
+            print(f"<torch_result>: {stack_ms}")
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[dtype] BOTH SUPPORT (from test_stack_dtype): "
+                  f"torch.stack support {stack_torch.dtype} "
+                  f"& mindspore.mint.stack support {stack_ms.dtype}.")
+        elif torch_support == ms_support == False:
+            print(f"[dtype] BOTH NOT SUPPORT (from test_stack_dtype): "
+                  f"torch.stack does not support {input_torch1.dtype} "
+                  f"& mindspore.mint.stack does not support {input_ms1.dtype}.")
+        elif torch_support == True and ms_support == False:
+            print(f"[dtype] ONLY TORCH (from test_stack_dtype): "
+                  f"torch.stack support {stack_torch.dtype} "
+                  f"but mindspore.mint.stack NOT.")
+        else:
+            print(f"[dtype] ONLY MS (from test_stack_dtype): "
+                  f"mindspore.mint.stack support {stack_ms.dtype} "
+                  f"but torch.stack NOT.")
+
+        print('='*50)
+
+#b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
+def test_stack_output():
+    print("--->This function: test mindspore.mint.stack [output]<---")
+    #共同支持以下类型
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+    
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            input_np1 = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_np2 = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+        elif dtype == 'bfloat16':
+            input_np1 = np.random.rand(3, 3).astype(np.float32)
+            input_np2 = np.random.rand(3, 3).astype(np.float32)
+            input_torch1 = torch.from_numpy(input_np1).type(torch.bfloat16)
+            input_ms1 = Tensor.from_numpy(input_np1).astype(ms.bfloat16)
+            input_torch2 = torch.from_numpy(input_np2).type(torch.bfloat16)
+            input_ms2 = Tensor.from_numpy(input_np2).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np1 = np.random.rand(3, 3).astype(dtype)
+            input_np2 = np.random.rand(3, 3).astype(dtype)
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+        else:
+            input_np1 = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_np2 = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch1 = torch.from_numpy(input_np1)
+            input_ms1 = Tensor.from_numpy(input_np1)
+            input_torch2 = torch.from_numpy(input_np2)
+            input_ms2 = Tensor.from_numpy(input_np2)
+
+        stack_torch = torch.stack([input_torch1, input_torch2], dim=0)
+        stack_ms = mint.stack([input_ms1, input_ms2], dim=0)
+        
+        if dtype == 'bfloat16':
+            print("current type: bfloat16\n"
+                 f"<result_torch>: {stack_torch}\n"
+                 f"<result_torch>: {stack_ms}")
+        else:
+            if np.allclose(stack_torch.numpy(), stack_ms.asnumpy(), atol=1e-3):
+                print("[output] WITHIN TOLERANCE (from test_stack_output): "
+                      "output discrepancy between torch.stack "
+                      "mindspore.mint.stack is less than 1e-3.")
+            else:
+                print("[output] BEYOND TOLERANCE (from test_stack_output): "
+                      "output discrepancy is beyond tolerance.")
+        
+        print('='*50)
+
+#c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
+def test_stack_paramType():
+    print("--->This function: test mindspore.mint.stack [paramType]<---")
+
+    input_np1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).astype(np.float32)
+    input_torch1 = torch.from_numpy(input_np1)
+    input_ms1 = Tensor.from_numpy(input_np1)
+
+    input_np2= np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5], [7.5, 8.5, 9.5]]).astype(np.float32)
+    input_torch2 = torch.from_numpy(input_np2)
+    input_ms2 = Tensor.from_numpy(input_np2)
+
+    params = (("abc", 'string'), 
+              (True, 'bool'), 
+              (0, 'int'), 
+              (1.0, 'float'), 
+              ([1, 2], 'list'),
+              ((0, 1), 'tuple')
+              )
+
+    for (param, param_type) in params:
+        #test
+        torch_support = True
+        ms_support = True
+        try:
+            stack_torch = torch.stack([input_torch1, input_torch2], dim=param)
+        except:
+            torch_support = False
+
+        try:
+            stack_ms = mint.stack([input_ms1, input_ms2], dim=param)
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[paramType: {param_type}] BOTH SUPPORT(from test_stack_paramType).")
+        elif torch_support == ms_support == False:
+            print(f"[paramType: {param_type}] BOTH NOT SUPPORT(from test_stack_paramType).")
+        elif torch_support == True and ms_support == False:
+            print(f"[paramType: {param_type}] ONLY TORCH(from test_stack_paramType): "
+                  "torch.stack support but mindspore.mint.stack NOT.")
+        else:
+            print(f"[paramType: {param_type}] ONLY MS(from test_stack_paramType): "
+                  "mindspore.mint.stack support but torch.stack NOT.")
+
+        print('='*50)
+
+#d) 测试随机混乱输入，报错信息的准确性
+def test_stack_errorMessage():
+    print("--->This function: test mindspore.mint.stack [errorMessage]<---")
+
+    #input tensors type not same TypeError
+    try:
+        input_np1 = np.random.rand(3, 3).astype(np.float32)
+        input_ms1 = Tensor.from_numpy(input_np1)
+        input_np2 = np.random.rand(3, 3).astype(np.int32)
+        input_ms2 = Tensor.from_numpy(input_np2)
+        dim1 = 0
+        stack_ms1 = mint.stack([input_ms1, input_ms2], dim=dim1)
+        print(stack_ms1)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_stack_errorMessage): "
+              "Test Target: input tensors type not same error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+    
+    #param dim out of range ValueError
+    try:
+        input_np3 = np.random.rand(3, 3).astype(np.float32)
+        input_ms3 = Tensor.from_numpy(input_np3)
+        input_np4 = np.random.rand(3, 3).astype(np.float32)
+        input_ms4 = Tensor.from_numpy(input_np4)
+        dim2 = 4
+        stack_ms2 = mint.stack([input_ms3, input_ms4], dim=dim2)
+        print(stack_ms2)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_stack_errorMessage): "
+              "Test Target: param dim value out of range error-ValueError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+    #input tensors shape not same ValueError
+    try:
+        input_np5 = np.random.rand(3).astype(np.float32)
+        input_ms5 = Tensor.from_numpy(input_np5)
+        input_np6 = np.random.rand(3, 3).astype(np.float32)
+        input_ms6 = Tensor.from_numpy(input_np6)
+        dim3 = 0
+        stack_ms3 = mint.stack([input_ms5, input_ms6], dim=dim3)
+        print(stack_ms3)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_stack_errorMessage): "
+              "Test Target: input tensors shape not same error-ValueError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+#2. 测试使用接口构造函数/神经网络的准确性
+#a) Github搜索带有该接口的代码片段/神经网络
+#b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
+#c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度
+def test_stack_value_and_grad():
+    w_np = np.random.randn(3, 1).astype(np.float32)
+    def model_torch(x):
+        w = torch.from_numpy(w_np)
+        f = torch.stack([x * x, x, torch.ones_like(x)], 1)
+        yhat = torch.squeeze(f @ w, 2)
+        return yhat
+    def model_ms(x):
+        w = Tensor.from_numpy(w_np)
+        f = mint.stack([x * x, x, ops.ones_like(x)], 1)
+        yhat = ops.squeeze(ops.matmul(f, w), 2)
+        return yhat
+    x_torch = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.float32, requires_grad=True)
+    x_ms = Parameter(Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=ms.float32))
+
+    y_torch = model_torch(x_torch)
+    y_ms = model_ms(x_ms)
+    
+    print(f"<value torch> {y_torch}\n"
+          f"<value_ms> {y_ms}")
+    if np.allclose(y_torch.detach().numpy(), y_ms.asnumpy(), atol=1e-3):
+        print("[value] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[value] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy is beyond tolerance.")
+    print('='*50)
+    
+    y_sum = y_torch.sum()
+    y_sum.backward()
+    grad_ms = ms.grad(model_ms, grad_position=0)(x_ms)
+    print(f"<grad torch> {x_torch.grad}\n"
+          f"<grad> {grad_ms}")
+    if np.allclose(x_torch.grad.numpy(), grad_ms.asnumpy(), atol=1e-3):
+        print("[grad] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[grad] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy is beyond tolerance.")
+    print('='*50)
+            
+if __name__ == '__main__':
+    test_stack_dtype()
+    test_stack_output()
+    test_stack_paramType()
+    test_stack_errorMessage()
+    test_stack_value_and_grad()

--- a/test/test_triu.py
+++ b/test/test_triu.py
@@ -1,0 +1,285 @@
+import mindspore as ms
+import numpy as np
+from mindspore import mint, Tensor, ops, nn
+import torch
+import torch.nn as nn_torch
+
+#triu:返回输入Tensor input 的上三角形部分(包含对角线和下面的元素)，并将其他元素设置为0。
+
+#1.对应Pytorch 的相应接口进行测试：
+#a) 测试random输入不同dtype，对比两个框架的支持度
+def test_triu_dtype():
+    print("--->This function: test mindspore.mint.triu [dtype]<---")
+
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            input_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        elif dtype == 'bfloat16':
+            input_np = np.random.rand(3, 3).astype(np.float32)
+            input_torch = torch.from_numpy(input_np).type(torch.bfloat16)
+            input_ms = Tensor.from_numpy(input_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np = np.random.rand(3, 3).astype(dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        else :
+            input_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+
+        torch_support = True
+        ms_support = True
+        #test
+        try:
+            triu_torch = torch.triu(input_torch)
+            print(f"<torch_result>: {triu_torch}")
+        except:
+            torch_support = False
+        
+        try:
+            triu_ms = mint.triu(input_ms)
+            print(f"<ms_result>: {triu_ms}")
+        except:
+            ms_support = False
+        
+        #result
+        if torch_support == ms_support == True:
+            print(f"[dtype] BOTH SUPPORT (from test_triu_dtype): "
+                  f"torch.triu support {triu_torch.dtype} "
+                  f"& mindspore.mint.triu support {triu_ms.dtype}.")
+        elif torch_support == ms_support == False:
+            print(f"[dtype] BOTH NOT SUPPORT (from test_triu_dtype): "
+                  f"torch.triu does not support {input_torch.dtype} "
+                  f"& mindspore.mint.triu does not support {input_ms.dtype}.")
+        elif torch_support == True and ms_support == False:
+            print(f"[dtype] ONLY TORCH (from test_triu_dtype): "
+                  f"torch.triu support {triu_torch.dtype} "
+                  f"but mindspore.mint.triu NOT.")
+        else:
+            print(f"[dtype] ONLY MS (from test_triu_dtype): "
+                  f"mindspore.mint.triu support {triu_ms.dtype} "
+                  f"but torch.triu NOT.")
+
+        print('='*50)
+
+#b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
+def test_triu_output():
+    print("--->This function: test mindspore.mint.triu [output]<---")
+    #共同支持以下类型
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.bool_, 'bfloat16']
+    
+    for dtype in np_dtypes:
+        if dtype == np.bool_:
+            input_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        elif dtype == 'bfloat16':
+            input_np = np.random.rand(3, 3).astype(np.float32)
+            input_torch = torch.from_numpy(input_np).type(torch.bfloat16)
+            input_ms = Tensor.from_numpy(input_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64):
+            input_np = np.random.rand(3, 3).astype(dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+        else :
+            input_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+
+        triu_torch = torch.triu(input_torch)
+        triu_ms = mint.triu(input_ms)
+        #numpy中没有bfloat16类型
+        if dtype == 'bfloat16':
+            print("current type: bfloat16\n"
+                 f"<result_torch>: {triu_torch}\n"
+                 f"<result_torch>: {triu_ms}")
+        else:
+            if np.allclose(triu_torch.numpy(), triu_ms.asnumpy(), atol=1e-3):
+                print("[output] WITHIN TOLERANCE (from test_triu_output): "
+                      "output discrepancy between torch.triu "
+                      "mindspore.mint.triu is less than 1e-3.")
+            else:
+                print("[output] BEYOND TOLERANCE (from test_triu_output): "
+                      "output discrepancy is beyond tolerance.")
+        
+        print('='*50)
+
+#c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
+def test_triu_paramType():
+    print("--->This function: test mindspore.mint.triu [paramType]<---")
+
+    input_np = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).astype(np.float32)
+
+    input_torch = torch.from_numpy(input_np)
+    input_ms = Tensor.from_numpy(input_np)
+
+    params = (("abc", 'string'), 
+              (True, 'bool'), 
+              (0, 'int'), 
+              (1.0, 'float'), 
+              ([1, 2], 'list'),
+              ((0, 1), 'tuple')
+              )
+
+    for (param, param_type) in params:
+        #test
+        torch_support = True
+        ms_support = True
+        try:
+            triu_torch = torch.triu(input_torch, param)
+        except:
+            torch_support = False
+
+        try:
+            triu_ms = mint.triu(input_ms, param)
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[paramType: {param_type}] BOTH SUPPORT(from test_triu_paramType).")
+        elif torch_support == ms_support == False:
+            print(f"[paramType: {param_type}] BOTH NOT SUPPORT(from test_triu_paramType).")
+        elif torch_support == True and ms_support == False:
+            print(f"[paramType: {param_type}] ONLY TORCH(from test_triu_paramType): "
+                  "torch.triu support but mindspore.mint.triu NOT.")
+        else:
+            print(f"[paramType: {param_type}] ONLY MS(from test_triu_paramType): "
+                  "mindspore.mint.triu support but torch.triu NOT.")
+
+        print('='*50)
+
+#d) 测试随机混乱输入，报错信息的准确性
+def test_triu_errorMessage():
+    print("--->This function: test mindspore.mint.triu [errorMessage]<---")
+
+    #input shape ValueError
+    try:
+        input_np1 = np.random.rand(3).astype(np.float32)
+        input_ms1 = Tensor.from_numpy(input_np1)
+        diagonal = 0
+        triu_ms1 = mint.triu(input_ms1, diagonal=diagonal)
+        print(triu_ms1)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_triu_errorMessage): "
+              "Test Target: input tensor shape error-ValueError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+    
+    #param diagonal TypeError
+    try:
+        input_np2 = np.random.rand(3, 3).astype(np.float32)
+        input_ms2 = Tensor.from_numpy(input_np2)
+        diagonal = False
+        triu_ms2 = mint.triu(input_ms2, diagonal=diagonal)
+        print(triu_ms2)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_triu_errorMessage): "
+              "Test Target: param diagonal type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+    #input tensor TypeError
+    
+    try:
+        input_ms3 = (1, 1)
+        diagonal = 0
+        triu_ms3 = mint.triu(input_ms3, diagonal=diagonal)
+        print(triu_ms3)
+    except Exception as e:
+        print("[errorMessage] ACCURACY TEST (from test_triu_errorMessage): "
+              "Test Target: input tensor type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+#2. 测试使用接口构造函数/神经网络的准确性
+#a) Github搜索带有该接口的代码片段/神经网络
+#b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
+#c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度
+def test_triu_value_and_grad():  
+    def gaussian_tailbound(d, b):
+        return ( d + 2*( d * math.log(1/b) )**0.5 + 2*math.log(1/b) )**0.5
+    
+    def test_torch(Y):
+        rho = 5
+        n = 5
+        d = 0.5
+        X = torch.tensor([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5], [7.5, 8.5, 9.5]], dtype=torch.float32)
+        A = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.float32)
+        W = torch.mm(X, A)
+        gamma = gaussian_tailbound(d, 0.1)
+        noise_var = (gamma**4/(rho*n**2))
+        Y = Y * np.sqrt(noise_var)    
+        Y = torch.triu(Y)
+        Y = Y + Y.t() - torch.diag_embed(Y.diagonal()) #Don't duplicate diagonal entries
+        Z = (torch.mm(W.t(), W))/n
+        #add noise    
+        Z = Z + Y
+        return Z
+    
+    def test_ms(Y):
+        rho = 5
+        n = 5
+        d = 0.5
+        X = Tensor([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5], [7.5, 8.5, 9.5]], dtype=ms.float32)
+        A = Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=ms.float32)
+        W = ops.mm(X, A)
+        gamma = gaussian_tailbound(d, 0.1)
+        noise_var = (gamma**4/(rho*n**2))
+        Y = Y * np.sqrt(noise_var)     
+        Y = mint.triu(Y)
+        Y = Y + Y.t() - ops.diag_embed(Y.diagonal()) #Don't duplicate diagonal entries
+        Z = (ops.mm(W.t(), W))/n
+        #add noise    
+        Z = Z + Y
+        return Z
+    
+    Y_np = np.random.randn(3, 3).astype(np.float32)
+    Y_torch = torch.from_numpy(Y_np)
+    Y_torch.requires_grad = True
+    Y_ms = Parameter(Tensor.from_numpy(Y_np))
+
+    y_torch = test_torch(Y_torch)
+    y_ms = test_ms(Y_ms)
+
+    print(f"<value torch> {y_torch}\n"
+          f"<value_ms> {y_ms}")
+    if np.allclose(y_torch.detach().numpy(), y_ms.asnumpy(), atol=1e-3):
+        print("[value] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[value] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy is beyond tolerance.")
+    print('='*50)
+    
+    y_sum = y_torch.sum()
+    y_sum.backward()
+    grad_ms = ms.grad(test_ms, grad_position=0)(Y_ms)
+    print(f"<grad torch> {Y_torch.grad}\n"
+          f"<grad> {grad_ms}")
+    if np.allclose(Y_torch.grad.numpy(), grad_ms.asnumpy(), atol=1e-3):
+        print("[grad] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[grad] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy is beyond tolerance.")
+    print('='*50)
+    
+if __name__ == '__main__':
+    test_triu_dtype()
+    test_triu_output()
+    test_triu_paramType()
+    test_triu_errorMessage()
+    test_triu_value_and_grad()

--- a/test/test_where.py
+++ b/test/test_where.py
@@ -1,0 +1,353 @@
+import mindspore as ms
+import numpy as np
+from mindspore import mint, Tensor, ops, Parameter
+import torch
+
+#where:返回一个Tensor，Tensor的元素从 input 或 other 中根据 condition 选择。
+
+#1.对应Pytorch 的相应接口进行测试：
+#a) 测试random输入不同dtype，对比两个框架的支持度
+def test_where_dtype():
+    print("--->This function: test mindspore.mint.where [dtype]<---")
+
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+
+    for dtype in np_dtypes:
+        condition_np = np.array(True)
+        condition_torch = torch.from_numpy(condition_np)
+        condition_ms = Tensor.from_numpy(condition_np)
+        if dtype == np.bool_:
+            input_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            other_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+        elif dtype == 'bfloat16':
+            input_np = np.random.rand(3, 3).astype(np.float32)
+            other_np = np.random.rand(3, 3).astype(np.float32)
+            input_torch = torch.from_numpy(input_np).type(torch.bfloat16)
+            input_ms = Tensor.from_numpy(input_np).astype(ms.bfloat16)
+            other_torch = torch.from_numpy(other_np).type(torch.bfloat16)
+            other_ms = Tensor.from_numpy(other_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np = np.random.rand(3, 3).astype(dtype)
+            other_np = np.random.rand(3, 3).astype(dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+        else:
+            input_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            other_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+
+        torch_support = True
+        ms_support = True
+        #test
+        try:
+            where_torch = torch.where(condition_torch, input_torch, other_torch)
+            print(f"<torch_result>: {where_torch}")
+        except:
+            torch_support = False
+
+        try:
+            where_ms = mint.where(condition_ms, input_ms, other_ms)
+            print(f"<torch_result>: {where_torch}")
+        except:
+            ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[dtype] BOTH SUPPORT (from test_where_dtype): "
+                  f"torch.where support {where_torch.dtype} "
+                  f"& mindspore.mint.where support {where_ms.dtype}.")
+        elif torch_support == ms_support == False:
+            print(f"[dtype] BOTH NOT SUPPORT (from test_where_dtype): "
+                  f"torch.where does not support {input_torch.dtype} "
+                  f"& mindspore.mint.where does not support {input_ms.dtype}.")
+        elif torch_support == True and ms_support == False:
+            print(f"[dtype] ONLY TORCH (from test_where_dtype): "
+                  f"torch.where support {where_torch.dtype} "
+                  f"but mindspore.mint.where NOT.")
+        else:
+            print(f"[dtype] ONLY MS (from test_where_dtype): "
+                  f"mindspore.mint.where support {where_ms.dtype} "
+                  f"but torch.where NOT.")
+
+        print('='*50)
+
+#b) 测试固定dtype，random输入值，对比两个框架输出是否相等（误差范围为小于1e-3）
+def test_where_output():
+    print("--->This function: test mindspore.mint.where [output]<---")
+    #共同支持以下类型
+    np_dtypes = [np.int8, np.int16, np.int32, np.int64,
+                 np.float16, np.float32, np.float64,
+                 np.uint8, np.complex64, np.complex128, np.bool_,
+                'bfloat16']
+    
+    for dtype in np_dtypes:
+        condition_np = np.array(True)
+        condition_torch = torch.from_numpy(condition_np)
+        condition_ms = Tensor.from_numpy(condition_np)
+        if dtype == np.bool_:
+            input_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            other_np = np.random.choice(np.array([True, False]), size=(3, 3))
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+        elif dtype == 'bfloat16':
+            input_np = np.random.rand(3, 3).astype(np.float32)
+            other_np = np.random.rand(3, 3).astype(np.float32)
+            input_torch = torch.from_numpy(input_np).type(torch.bfloat16)
+            input_ms = Tensor.from_numpy(input_np).astype(ms.bfloat16)
+            other_torch = torch.from_numpy(other_np).type(torch.bfloat16)
+            other_ms = Tensor.from_numpy(other_np).astype(ms.bfloat16)
+        elif (dtype == np.float16 or dtype == np.float32 or dtype == np.float64 or 
+        dtype == np.complex64 or dtype == np.complex128):
+            input_np = np.random.rand(3, 3).astype(dtype)
+            other_np = np.random.rand(3, 3).astype(dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+        else:
+            input_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            other_np = np.random.randint(0, 10, size=(3, 3), dtype=dtype)
+            input_torch = torch.from_numpy(input_np)
+            input_ms = Tensor.from_numpy(input_np)
+            other_torch = torch.from_numpy(other_np)
+            other_ms = Tensor.from_numpy(other_np)
+
+        where_torch = torch.where(condition_torch, input_torch, other_torch)
+        where_ms = mint.where(condition_ms, input_ms, other_ms)
+        #numpy中没有bfloat16类型
+        if dtype == 'bfloat16':
+            print("current type: bfloat16\n"
+                 f"<result_torch>: {where_torch}\n"
+                 f"<result_torch>: {where_ms}")
+        else:
+            if np.allclose(where_torch.numpy(), where_ms.asnumpy(), atol=1e-3):
+                print("[output] WITHIN TOLERANCE (from test_where_output): "
+                      "output discrepancy between torch.where "
+                      "mindspore.mint.where is less than 1e-3.")
+            else:
+                print("[output] BEYOND TOLERANCE (from test_where_output): "
+                      "output discrepancy is beyond tolerance.")
+        
+        print('='*50)
+
+#c) 测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度
+def test_where_paramType():
+    print("--->This function: test mindspore.mint.where [paramType]<---")
+
+    input_np = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).astype(np.float32)
+    input_torch = torch.from_numpy(input_np)
+    input_ms = Tensor.from_numpy(input_np)
+
+    other_np = np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5], [7.5, 8.5, 9.5]]).astype(np.float32)
+    other_torch = torch.from_numpy(other_np)
+    other_ms = Tensor.from_numpy(other_np)
+
+    params = (("abc", 'string'), 
+              (True, 'bool'), 
+              (0, 'int'), 
+              (1.0, 'float'), 
+              ([1, 2], 'list'),
+              ((0, 1), 'tuple'),
+              (np.random.choice(np.array([True, False]), size=3), 'Tensor')
+              )
+
+    for (param, param_type) in params:
+        #test
+        torch_support = True
+        ms_support = True
+        if param_type == 'Tensor':
+            param_torch = torch.from_numpy(param)
+            param_ms = Tensor.from_numpy(param)
+            try:
+                where_torch = torch.where(param_torch, input_torch, other_torch)
+            except:
+                torch_support = False
+
+            try:
+                where_ms = mint.where(param_ms, input_ms, other_ms)
+            except:
+                ms_support = False
+        else:
+            try:
+                where_torch = torch.where(param, input_torch, other_torch)
+            except:
+                torch_support = False
+
+            try:
+                where_ms = mint.where(param, input_ms, other_ms)
+            except:
+                ms_support = False
+
+        #result
+        if torch_support == ms_support == True:
+            print(f"[paramType: {param_type}] BOTH SUPPORT(from test_where_paramType).")
+        elif torch_support == ms_support == False:
+            print(f"[paramType: {param_type}] BOTH NOT SUPPORT(from test_where_paramType).")
+        elif torch_support == True and ms_support == False:
+            print(f"[paramType: {param_type}] ONLY TORCH(from test_where_paramType): "
+                  "torch.where support but mindspore.mint.where NOT.")
+        else:
+            print(f"[paramType: {param_type}] ONLY MS(from test_where_paramType): "
+                  "mindspore.mint.where support but torch.where NOT.")
+
+        print('='*50)
+
+#d) 测试随机混乱输入，报错信息的准确性
+def test_where_errorMessage():
+    print("--->This function: test mindspore.mint.where [errorMessage]<---")
+
+    #param condition TypeError
+    try:
+        condition1 = [True, True]
+        input_ms1 = Tensor([1, 2])
+        other_ms1 = Tensor([3, 4])
+        where_ms1 = mint.where(condition1, input_ms1, other_ms1)
+        print(where_ms1)
+    except Exception as e:
+        print(f"[errorMessage] ACCURACY TEST (from test_where_errorMessage): "
+              "Test Target: param condition type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+    #input other all const TypeError
+    try:
+        condition2 = Tensor(True)
+        input_ms2 = 1
+        other_ms2 = 2
+        where_ms2 = mint.where(condition2, input_ms2, other_ms2)
+        print(where_ms2)
+    except Exception as e:
+        print(f"[errorMessage] ACCURACY TEST (from test_where_errorMessage): "
+              "Test Target: input&other tensor type error-TypeError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+    #can not broadcast ValueError
+    try:
+        condition3 = Tensor([[True, False],[False, True]])
+        input_ms3 = Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        other_ms3 = Tensor([[[1, 2, 3, 0], [4, 5, 6, 0], [7, 8, 9, 0]],
+                           [[1, 2, 3, 0], [4, 5, 6, 0], [7, 8, 9, 0]]])
+        where_ms3 = mint.where(condition3, input_ms3, other_ms3)
+        print(where_ms3)
+    except Exception as e:
+        print(f"[errorMessage] ACCURACY TEST (from test_where_errorMessage): "
+              "Test Target: can not broadcast error-ValueError.\n"
+              f"Catch Exception:\n{type(e).__name__}: {e}.")
+    print('='*50)
+
+#2. 测试使用接口构造函数/神经网络的准确性
+#a) Github搜索带有该接口的代码片段/神经网络
+#b) 使用Pytorch和MindSpore，固定输入和权重，测试正向推理结果（误差范围小于1e-3，若报错则记录报错信息）
+#c) 测试该神经网络/函数反向，如果是神经网络，则测试Parameter的梯度，如果是函数，则测试函数输入的梯度
+def test_where_value_and_grad():
+    def ternarize_torch(tensor):
+        delta = get_delta_torch(tensor)
+        alpha = get_alpha_torch(tensor, delta)
+        pos = torch.where(tensor > delta, 1, tensor)
+        neg = torch.where(pos<-delta, -1, pos)
+        ternary = torch.where((neg >= -delta) & (neg <= delta), 0, neg)
+        return ternary * alpha
+
+    def get_alpha_torch(tensor, delta):
+        ndim = len(tensor.shape)
+        view_dims = (-1,) + (ndim - 1)*(1,)
+        i_delta = (torch.abs(tensor) > delta)
+        i_delta_count = i_delta.view(i_delta.shape[0], -1).sum(1)
+        tensor_thresh = torch.where((i_delta), tensor, 0)
+        alpha = (1 / i_delta_count)*(torch.abs(tensor_thresh.view(tensor.shape[0], -1)).sum(1))
+        alpha = alpha.view(view_dims)
+        return alpha
+
+    def get_delta_torch(tensor):
+        ndim = len(tensor.shape)
+        view_dims = (-1,) + (ndim - 1) * (1,)
+        n = tensor[0].nelement()
+        norm = tensor.norm(1, ndim - 1).view(tensor.shape[0], -1)
+        norm_sum = norm.sum(1)
+        delta = (0.75 / n) * norm_sum
+        return delta.view(view_dims)
+    
+    def ternarize_ms(tensor):
+        delta = get_delta_ms(tensor)
+        alpha = get_alpha_ms(tensor, delta)
+        pos = mint.where(tensor > delta, 1, tensor)
+        neg = mint.where(pos<-delta, -1, pos)
+        condition = ops.logical_and((neg >= -delta), (neg <= delta))
+        ternary = mint.where(condition, 0, neg)
+        return ternary * alpha
+
+    def get_alpha_ms(tensor, delta):
+        ndim = len(tensor.shape)
+        view_dims = (-1,) + (ndim - 1)*(1,)
+        i_delta = (ops.abs(tensor) > delta)
+        i_delta_count = i_delta.view(i_delta.shape[0], -1).sum(1)
+        tensor_thresh = mint.where((i_delta), tensor, 0)
+        alpha = (1 / i_delta_count)*(ops.abs(tensor_thresh.view(tensor.shape[0], -1)).sum(1))
+        alpha = alpha.view(view_dims)
+        return alpha
+
+    def get_delta_ms(tensor):
+        ndim = len(tensor.shape)
+        view_dims = (-1,) + (ndim - 1) * (1,)
+        n = tensor[0].nelement()
+        norm = tensor.norm(1, ndim - 1).view(tensor.shape[0], -1)
+        norm_sum = norm.sum(1)
+        delta = (0.75 / n) * norm_sum
+        return delta.view(view_dims)
+    
+    x_np = np.random.randn(3, 3).astype(np.float32)
+    x_torch = torch.from_numpy(x_np)
+    x_torch.requires_grad = True
+    x_ms = Parameter(Tensor.from_numpy(x_np))
+
+    y_torch = ternarize_torch(x_torch)
+    y_ms = ternarize_ms(x_ms)
+
+    print(f"<value torch> {y_torch}\n"
+          f"<value_ms> {y_ms}")
+    if np.allclose(y_torch.detach().numpy(), y_ms.asnumpy(), atol=1e-3):
+        print("[value] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[value] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "value discrepancy is beyond tolerance.")
+    print('='*50)
+    
+    y_sum = y_torch.sum()
+    y_sum.backward()
+    grad_ms = ms.grad(ternarize_ms, grad_position=0)(x_ms)
+    print(f"<grad torch> {x_torch.grad}\n"
+          f"<grad> {grad_ms}")
+    if np.allclose(x_torch.grad.numpy(), grad_ms.asnumpy(), atol=1e-3):
+        print("[grad] WITHIN TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy between torch.stack "
+              "mindspore.mint.stack is less than 1e-3.")
+    else:
+        print("[grad] BEYOND TOLERANCE (from test_stack_value_and_grad): "
+              "grad discrepancy is beyond tolerance.")
+    print('='*50)
+    
+if __name__ == '__main__':
+    test_where_dtype()
+    test_where_output()
+    test_where_paramType()
+    test_where_errorMessage()
+    test_where_value_and_grad()


### PR DESCRIPTION
以下为提交的问题ISSUE链接：
1. 类型不支持问题：
[mindspore.mint.triu()不支持complex64,complex128类型输入](https://gitee.com/mindspore/mindspore/issues/IBDQDT?from=project-issue)
[mindspore.mint.rand_like()不支持complex64,complex128类型输入](https://gitee.com/mindspore/mindspore/issues/IBDQEV?from=project-issue)
[mindspore.mint.normal()不支持blfoat16类型输入](https://gitee.com/mindspore/mindspore/issues/IBDQGA?from=project-issue)
[mindspore.mint.normal()参数size不支持列表list类型](https://gitee.com/mindspore/mindspore/issues/IBDQIN?from=project-issue)
2. 易用性问题：
[mindspore.mint.where()参数condition在需要多个逻辑表达式情况下的写法有些麻烦](https://gitee.com/mindspore/mindspore/issues/IBDQKI?from=project-issue)