### PR TITLE
测试mint.rand、mint.abs、mint.add、mint.acos、mint.acosh

### DIFF
--- a/test/test_abs.py
+++ b/test/test_abs.py
@@ -1,0 +1,102 @@
+import pytest
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+
+dtype_ms = ms.float32
+dtype_torch = torch.float32
+input_data = [[1, -6, 2.7, -4.5],[-7.9, 3.2, 8, 2],[2, 9.1, -11.7, 5]]
+ms_tensor = Tensor(input_data, dtype_ms)
+torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+
+def is_same(input_data=[[1, -6, 2.7, -4.5],[-7.9, 3.2, 8, 2],[2, 9.1, -11.7, 5]], shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_data = np.random.randn(*shape)
+
+    ms_tensor = Tensor(input_data, dtype_ms)
+    torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+
+    ms_result = mint.abs(ms_tensor)
+    torch_result = torch.abs(torch_tensor)
+    return np.allclose(ms_result.asnumpy(), torch_result.numpy())
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_abs_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    ms_dtypes = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16, ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+    torch_dtypes = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32, torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+    for i in range(len(ms_dtypes)):
+        dtype_ms = ms_dtypes[i]
+        dtype_torch = torch_dtypes[i]
+
+        ms_tensor = Tensor(input_data, dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.abs(ms_tensor).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.abs not supported for {dtype_ms}")
+            # print(e)
+
+        try:
+            torch_result = torch.abs(torch_tensor).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.abs not supported for {dtype_torch}")
+            # print(e)
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_abs_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        result = is_same(shape=shape)
+        assert result
+            
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_abs_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+
+    try:
+        ms_result = mint.abs(input_data).asnumpy()
+    except Exception as e:
+        print(f"input不是 Tensor 报错信息：\n{e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_abs_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+    torch_tensor = torch.tensor(input_data, dtype=dtype_torch, requires_grad=True)
+
+    def forward_pt(x):
+        return torch.abs(x).sum()
+    
+    def forward_ms(x):
+        return mint.abs(x).sum()
+    
+    grad_fn = value_and_grad(forward_ms)
+    output_ms, gradient_ms = grad_fn(ms_tensor)
+    output_pt = forward_pt(torch_tensor)
+    output_pt.backward()
+    gradient_pt = torch_tensor.grad
+    assert np.allclose(output_ms.asnumpy(), output_pt.detach().numpy(), atol=1e-3)
+    assert np.allclose(gradient_ms.asnumpy(), gradient_pt.numpy(), atol=1e-3)

--- a/test/test_acos.py
+++ b/test/test_acos.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+
+def prepare_data(x=[[0.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -0.11, 0.5]], dtype_ms=ms.float32, dtype_torch=torch.float32, requires_grad=False):
+    
+    ms_x = Tensor(x, dtype=dtype_ms)
+    torch_x = torch.tensor(x, dtype=dtype_torch, requires_grad=requires_grad)
+    return ms_x, torch_x
+
+
+def is_same(input_x=[[0.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -0.11, 0.5]], shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_x = np.random.uniform(-1, 1, size=shape)
+    
+    ms_x, torch_x = prepare_data(input_x)
+
+    ms_result = mint.acos(ms_x)
+    torch_result = torch.acos(torch_x)
+    return np.allclose(ms_result.asnumpy(), torch_result.numpy(), atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acos_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    ms_dtypes = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.float16, ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+    torch_dtypes = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+    for i in range(len(ms_dtypes)):
+        dtype_ms = ms_dtypes[i]
+        dtype_torch = torch_dtypes[i]
+
+        ms_x, torch_x = prepare_data(dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.acos(ms_x).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.acos not supported for {dtype_ms}")
+            # print(e)
+
+        try:
+            torch_result = torch.acos(torch_x).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.acos not supported for {dtype_torch}")
+            # print(e)
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acos_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        result = is_same(shape=shape)
+        assert result
+            
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acos_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    ms_x, torch_x = prepare_data([[1.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -1.11, 0.5]])
+
+    try:
+        ms_result = mint.acos(ms_x).asnumpy()
+    except Exception as e:
+        print(f"input超过 [-1,1] 报错信息：\n{e}")
+        
+    try:
+        ms_result = mint.acos([[1.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -1.11, 0.5]]).asnumpy()
+    except Exception as e:
+        print(f"input不是 Tensor 报错信息：\n{e}")
+        
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acos_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+    ms_x, torch_x = prepare_data(requires_grad=True)
+
+    def forward_pt(x):
+        return torch.acos(x).sum()
+    
+    def forward_ms(x):
+        return mint.acos(x).sum()
+    
+    grad_fn = value_and_grad(forward_ms)
+    output_ms, gradient_ms = grad_fn(ms_x)
+    output_pt = forward_pt(torch_x)
+    output_pt.backward()
+    gradient_pt = torch_x.grad
+    assert np.allclose(output_ms.asnumpy(), output_pt.detach().numpy(), atol=1e-3)
+    assert np.allclose(gradient_ms.asnumpy(), gradient_pt.numpy(), atol=1e-3)

--- a/test/test_acosh.py
+++ b/test/test_acosh.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+
+def prepare_data(x=[[1.74, 19.04, 16.30, 1.56],[24.7, 76.3, 5.8, 24.2],[17.0, 73.9, 27.11,9.5]], dtype_ms=ms.float32, dtype_torch=torch.float32, requires_grad=False):
+    
+    ms_x = Tensor(x, dtype=dtype_ms)
+    torch_x = torch.tensor(x, dtype=dtype_torch, requires_grad=requires_grad)
+    return ms_x, torch_x
+
+
+def is_same(input_x=[[1.74, 19.04, 16.30, 1.56],[24.7, 76.3, 5.8, 24.2],[17.0, 73.9, 27.11,9.5]], shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_x = np.random.uniform(1, 1000, size=shape)
+    
+    ms_x, torch_x = prepare_data(input_x)
+
+    ms_result = mint.acosh(ms_x)
+    torch_result = torch.acosh(torch_x)
+    return np.allclose(ms_result.asnumpy(), torch_result.numpy(), atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acosh_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    
+    ms_dtypes = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.float16, ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+    torch_dtypes = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+    for i in range(len(ms_dtypes)):
+        dtype_ms = ms_dtypes[i]
+        dtype_torch = torch_dtypes[i]
+
+        ms_x, torch_x = prepare_data(dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.acosh(ms_x).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.acosh not supported for {dtype_ms}")
+            # print(e)
+
+        try:
+            torch_result = torch.acosh(torch_x).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.acosh not supported for {dtype_torch}")
+            # print(e)
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acosh_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        result = is_same(shape=shape)
+        assert result
+            
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acosh_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    ms_x, torch_x = prepare_data([[1.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -1.11, 0.5]])
+
+    try:
+        ms_result = mint.acosh(ms_x).asnumpy()
+    except Exception as e:
+        print(f"input 小于 1 报错信息：\n{e}")
+
+    try:
+        ms_result = mint.acos([[1.74, 0.04, 0.30, 0.56],[-0.7, 0.3, 0.8, 0.2],[1.0, 0.9, -1.11, 0.5]]).asnumpy()
+    except Exception as e:
+        print(f"input不是 Tensor 报错信息：\n{e}")
+        
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_acosh_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+    ms_x, torch_x = prepare_data(requires_grad=True)
+
+    def forward_pt(x):
+        return torch.acosh(x).sum()
+    
+    def forward_ms(x):
+        return mint.acosh(x).sum()
+    
+    grad_fn = value_and_grad(forward_ms)
+    output_ms, gradient_ms = grad_fn(ms_x)
+    output_pt = forward_pt(torch_x)
+    output_pt.backward()
+    gradient_pt = torch_x.grad
+    assert np.allclose(output_ms.asnumpy(), output_pt.detach().numpy(), atol=1e-3)
+    assert np.allclose(gradient_ms.asnumpy(), gradient_pt.numpy(), atol=1e-3)

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -1,0 +1,127 @@
+import pytest
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+import torch
+
+
+def prepare_data(x=[[1, 6, 2, 4],[7, 3, 8, 2],[2, 9, 11, 5]], y=[[3, 8, 1, 9],[4, 2, 4, 3],[8, 7, 23, 15]], dtype_ms=ms.float32, dtype_torch=torch.float32, requires_grad=False):
+    
+    ms_x = Tensor(x, dtype=dtype_ms)
+    ms_y = Tensor(y, dtype=dtype_ms)
+    torch_x = torch.tensor(x, dtype=dtype_torch, requires_grad=requires_grad)
+    torch_y = torch.tensor(y, dtype=dtype_torch, requires_grad=requires_grad)
+    return ms_x, ms_y, torch_x, torch_y
+
+
+def is_same(input_x=[[1,6,2,4],[7,3,8,2],[2, 9, 11, 5]], input_y=[[3, 8, 1, 9],[4, 2, 4, 3],[8, 7, 23, 15]], alpha=1, shape=None, dtype_ms=ms.float32, dtype_torch=torch.float32):
+    if shape != None:
+        input_x = np.random.randn(*shape)
+        input_y = np.random.randn(*shape)
+    
+    ms_x, ms_y, torch_x, torch_y = prepare_data(input_x, input_y, dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+
+    ms_result = mint.add(ms_x, ms_y, alpha=alpha)
+    torch_result = torch.add(torch_x, torch_y, alpha=alpha)
+    return np.allclose(ms_result.asnumpy(), torch_result.numpy())
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_add_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+    ms_dtypes = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16, ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+    torch_dtypes = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32, torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+    for i in range(len(ms_dtypes)):
+        dtype_ms = ms_dtypes[i]
+        dtype_torch = torch_dtypes[i]
+
+        ms_x, ms_y, torch_x, torch_y = prepare_data(dtype_ms=dtype_ms, dtype_torch=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.add(ms_x, ms_y).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.add not supported for {dtype_ms}")
+            # print(e)
+
+        try:
+            torch_result = torch.add(torch_x, torch_y).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.add not supported for {dtype_torch}")
+            # print(e)
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_add_random_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        result = is_same(shape=shape)
+        assert result
+        
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_add_different_para(mode):
+    """测试固定shape，固定输入值，不同输入参数（string\bool等类型），两个框架的支持度"""
+    ms.set_context(mode=mode)
+
+    alphas = [0.5, 1, -2, 2.5, True]
+    dtype_mss = [ms.float32, ms.int32, ms.int32, ms.float16, ms.bool_]
+    dtype_torchs=[torch.float32, torch.int32, torch.int32, torch.float16, torch.bool]
+    for dtype_ms, dtype_torch, alpha in zip(dtype_mss, dtype_torchs, alphas):
+        result = is_same(dtype_ms=dtype_ms, dtype_torch=dtype_torch, alpha=alpha)
+        assert result
+            
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_add_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    input_x=[[1,6,2,4],[7,3,8,2],[2, 9, 11, 5]]
+    input_y=[[3, 8, 1, 9],[4, 2, 4, 3],[8, 7, 23, 15]]
+
+    try:
+        ms_result = mint.add(input_x, input_y).asnumpy()
+    except Exception as e:
+        print(f"input不是 Tensor、number.Number、bool 报错信息：\n{e}")
+        
+    try:
+        ms_result = mint.add(input_x, input_y, alpha=1.5).asnumpy()
+    except Exception as e:
+        print(f"alpha 是 float 类型，但是 input 不是 float 类型 报错信息：\n{e}")
+        
+    try:
+        ms_result = mint.add(input_x, input_y, alpha=True).asnumpy()
+    except Exception as e:
+        print(f"alpha 是 bool 类型，但是 input 不是 bool 类型 报错信息：\n{e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_add_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+    ms_x, ms_y, torch_x, torch_y = prepare_data(requires_grad=True)
+
+    def forward_pt(x, y):
+        return torch.add(x, y).sum()
+    
+    def forward_ms(x, y):
+        return mint.add(x, y).sum()
+    
+    grad_fn = value_and_grad(forward_ms)
+    output_ms, gradient_ms = grad_fn(ms_x, ms_y)
+    output_pt = forward_pt(torch_x, torch_y)
+    output_pt.backward()
+    gradient_pt = torch_x.grad
+    assert np.allclose(output_ms.asnumpy(), output_pt.detach().numpy(), atol=1e-3)
+    assert np.allclose(gradient_ms.asnumpy(), gradient_pt.numpy(), atol=1e-3)

--- a/test/test_rand.py
+++ b/test/test_rand.py
@@ -1,0 +1,90 @@
+import pytest
+import numpy as np
+import mindspore as ms
+
+from mindspore import mint
+import torch
+
+
+dtype_ms = ms.float32
+dtype_torch = torch.float32
+
+shape = [3, 4]
+rand_seed = np.random.randint(100)
+
+def is_same(tensor_ms, tensor_torch):
+    return np.allclose(tensor_ms.asnumpy(), tensor_torch.numpy())
+
+@ms.jit()
+def rand_jit(shape, generator=None, dtype=None):
+    return mint.rand(*shape, generator=generator, dtype=dtype)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_rand_different_dtypes(mode):
+    """测试random输入不同dtype，对比两个框架的支持度"""
+    ms.set_context(mode=mode)
+
+    ms_dtypes = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16, ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+    torch_dtypes = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32, torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+    for i in range(len(ms_dtypes)):
+        dtype_ms = ms_dtypes[i]
+        dtype_torch = torch_dtypes[i]
+
+        err = False
+        try:
+            ms_result = rand_jit(shape, dtype=dtype_ms).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"mint.rand not supported for {dtype_ms}")
+            # print(e)
+
+        try:
+            torch_result = torch.rand(*shape, dtype=dtype_torch).numpy()
+        except Exception as e:
+            err = True
+            print(f"torch.rand not supported for {dtype_torch}")
+            # print(e)
+            
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_rand_input_fixed_dtype(mode):
+    """测试固定数据类型下的随机输入值，对比输出误差"""
+    ms.set_context(mode=mode)
+        
+    rand_seed = np.random.randint(100)
+    
+    generator_ms = ms.Generator()
+    generator_ms.manual_seed(rand_seed)
+    generator_torch = torch.Generator()
+    generator_torch.manual_seed(rand_seed)
+    
+    result_ms = rand_jit(shape, generator_ms, dtype_ms)
+    result_torch = torch.rand(*shape, generator=generator_torch, dtype=dtype_torch)
+    # result = is_same(result_ms, result_torch)
+    # assert result
+
+    
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_rand_wrong_input(mode):
+    """测试随机混乱输入，报错信息的准确性"""
+    ms.set_context(mode=mode)
+    
+    dtype_ms = ms.int32
+
+    size = [3.4, 4.5]
+    
+    try:
+        ms_result = rand_jit(size).asnumpy()
+        print(ms_result)
+    except Exception as e:
+        print(f"size 不是整数类型报错信息：\n{e}")
+        
+    try:
+        ms_result = rand_jit([3,4], dtype=dtype_ms).asnumpy()
+        print(ms_result)
+    except Exception as e:
+        print(f"dtype 不是浮点类型报错信息：\n{e}")
+        
+    


### PR DESCRIPTION
[测试记录.xlsx](https://github.com/user-attachments/files/18318526/default.xlsx)
mint.acos 和 mint.acosh 不支持输入 uint16 和 uint32 类型issue：https://gitee.com/mindspore/mindspore/issues/IBG1FR
创建 tensor 时负数转成无符号整数(如uint32等)行为与pytorch不一致issue:
https://gitee.com/mindspore/mindspore/issues/IBG1GY
